### PR TITLE
Fix for -Path parameter in New-UDImage

### DIFF
--- a/src/UniversalDashboard.UITest/Cmdlet/New-UDImage.Tests.ps1
+++ b/src/UniversalDashboard.UITest/Cmdlet/New-UDImage.Tests.ps1
@@ -5,7 +5,11 @@ $ModulePath = Get-ModulePath -Release:$Release
 Import-Module $ModulePath -Force
 Describe "New-UDImage" {
     It "should support url parameter" {
-        $Image = New-UDImage -Url http://www.google.com/image.png 
+        $Image = New-UDImage -Url http://www.google.com/image.png
         $Image.Attributes['src'] | Should be 'http://www.google.com/image.png'
+    }
+
+    It "should support path parameter"{
+        (New-UDImage -Path $PSCommandPath).Attributes.Src | should not be $null
     }
 }

--- a/src/UniversalDashboard/Controls/src/image.ps1
+++ b/src/UniversalDashboard/Controls/src/image.ps1
@@ -1,10 +1,11 @@
 function New-UDImage {
+    [CmdletBinding(DefaultParameterSetName = 'url')]
     param(
         [Parameter()]
         [String]$Id = (New-Guid),
-        [Parameter()]
+        [Parameter(ParameterSetName = 'url')]
         [String]$Url,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'path')]
         [String]$Path,
         [Parameter()]
         [int]$Height,
@@ -14,23 +15,26 @@ function New-UDImage {
         [Hashtable]$Attributes = @{}
     )
 
-    if (-not [String]::IsNullOrEmpty($Path)) {
-        if (-not (Test-Path $Path)) {
-            throw "$Path does not exist."
+    switch ($PSCmdlet.ParameterSetName) {
+        'path' {
+            if (-not [String]::IsNullOrEmpty($Path)) {
+                if (-not (Test-Path $Path)) {
+                    throw "$Path does not exist."
+                }
+        
+                $mimeType = 'data:image/png;base64, '
+                if ($Path.EndsWith('jpg') -or $Path.EndsWith('jpeg')) {
+                    $mimeType = 'data:image/jpg;base64, '
+                }
+        
+                $base64String = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($Path))
+        
+                $Attributes.'src' = "$mimeType $base64String"
+            }
         }
-
-        $mimeType = 'data:image/png;base64, '
-        if ($Path.EndsWith('jpg') -or $Path.EndsWith('jpeg')) {
-            $mimeType = 'data:image/jpg;base64, '
+        'url' {
+            $Attributes.'src' = $Url
         }
-
-        $base64String = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($Path))
-
-        $Url = "$mimeType $base64String"
-    }
-
-    if ($PSBoundParameters.ContainsKey('Url')) {
-        $Attributes.'src' = $Url
     }
     if ($PSBoundParameters.ContainsKey('Height')) {
         $Attributes.'height' = $Height


### PR DESCRIPTION
New-UDImage -Path parameter was not working after recent merge that resulted in $Attributes.'src' only being set if the -URL paramter was used.  This patch adds parameter sets to New-UDImage for the 2 usage scenarios and adds a test for the -path parameter.  I'm new to writing pester tests and am not sure if using $PSCommandPath will work for the test -Path value in your testing environment but it does work on my local system.  