### PR TITLE
Disable auto close when year selected

### DIFF
--- a/src/client/src/app/ud-input-field.jsx
+++ b/src/client/src/app/ud-input-field.jsx
@@ -23,7 +23,7 @@ export default class UdInputField extends React.Component {
         var comp = this;
 
         $(this.datetime).pickadate({
-            selectYears: 15,
+            selectYears: 100,
             clearText: this.props.clearText,
             okText: this.props.okText,
             cancelText: this.props.cancelText,
@@ -33,7 +33,7 @@ export default class UdInputField extends React.Component {
                 var val = this.get('select', 'dd-mm-yyyy');
                 comp.onTextFieldChange({name: comp.props.name},  {target: {value: val}});
                 // auto close on select
-                this.close();
+                //this.close();
             }
         })
     }


### PR DESCRIPTION
Now when you select the year the window will not close, and I change the value from 7 years back to 50 by default.

Fixes #388 