### PR TITLE
Fix add support for chart and monitor custom size

### DIFF
--- a/src/UniversalDashboard.UITest/Integration/Chart.Tests.ps1
+++ b/src/UniversalDashboard.UITest/Integration/Chart.Tests.ps1
@@ -85,5 +85,43 @@ Describe "Chart" {
        Stop-UDDashboard -Server $Server 
     }
 
+    Context "Custom Size" {
+        $dashboard = New-UDDashboard -Title "Test" -Content {
+            New-UDChart -Title "Chart" -Id "Chart" -Type Line -EndPoint {
+                $data = @(
+                    [PSCustomObject]@{"Day" = 1; Jpg = "10"; MP4= "30"}
+                    [PSCustomObject]@{"Day" = 2; Jpg = "20"; MP4= "20"}
+                    [PSCustomObject]@{"Day" = 3; Jpg = "30"; MP4= "10"}
+                )
+
+                $data | Out-UDChartData -LabelProperty "Day" -Dataset @(
+                    New-UDChartDataset -DataProperty "Jpg" -Label "Jpg" -BackgroundColor "#80962F23" -HoverBackgroundColor "#80962F23"
+                    New-UDChartDataset -DataProperty "MP4" -Label "MP4" -BackgroundColor "#8014558C" -HoverBackgroundColor "#8014558C"
+                ) 
+            } -Links @(
+                New-UDLink -Text "My Link" -Url "http://www.google.com"
+            ) -Width 30vw -Height 300px
+        } 
+
+        $Server = Start-UDDashboard -Port 10001 -Dashboard $dashboard 
+        $Driver = Start-SeFirefox
+        Enter-SeUrl -Driver $Driver -Url "http://localhost:$BrowserPort"
+
+        $charts = Find-SeElement -Driver $driver -ClassName 'ud-chart'
+        $chartContent = $charts.FindElementByClassName('card-content')
+        $chartStyle = Get-SeElementAttribute -Element $chartContent -Attribute 'style'
+
+        It "should have custom width size" {
+            (($chartStyle -split ';') -split 'width:')[1].trim() | Should be '30vw'
+        }
+
+        It "should have custom height size" {
+            (($chartStyle -split ';') -split 'height:')[2].trim() | Should be '300px'
+        }
+
+       Stop-SeDriver $Driver
+       Stop-UDDashboard -Server $Server 
+    }
+
 
 }

--- a/src/UniversalDashboard/Cmdlets/Charting/NewChartCommand.cs
+++ b/src/UniversalDashboard/Cmdlets/Charting/NewChartCommand.cs
@@ -21,6 +21,10 @@ namespace UniversalDashboard.Cmdlets.Charting
 		public string Title { get; set; }
 		[Parameter]
 		public Hashtable Options { get; set; }
+		[Parameter]
+		public string Width { get; set; }
+		[Parameter]
+		public string Height { get; set; }
 
 		[Parameter]
 		public DashboardColor BackgroundColor { get; set; }
@@ -42,6 +46,8 @@ namespace UniversalDashboard.Cmdlets.Charting
 				ChartType = Type,
 				Callback = GenerateCallback(Id),
 				Options = Options,
+				Width = Width,
+				Height = Height,
 				AutoRefresh = AutoRefresh,
 				RefreshInterval = RefreshInterval,
 				BackgroundColor = BackgroundColor?.HtmlColor,

--- a/src/UniversalDashboard/Cmdlets/Charting/NewMonitorCommand.cs
+++ b/src/UniversalDashboard/Cmdlets/Charting/NewMonitorCommand.cs
@@ -38,6 +38,10 @@ namespace UniversalDashboard.Cmdlets.Charting
 		[Parameter]
 		public DashboardColor BackgroundColor { get; set; }
 		[Parameter]
+		public string Width { get; set; }
+		[Parameter]
+		public string Height { get; set; }
+		[Parameter]
 		public DashboardColor FontColor { get; set; }
 		[Parameter]
 		public int BorderWidth { get; set; } = 1;
@@ -56,6 +60,8 @@ namespace UniversalDashboard.Cmdlets.Charting
 				ChartType = Type,
 				Callback = GenerateCallback(Id),
 				Options = Options,
+				Width = Width,
+				Height = Height,
 				Live = true,
 				Labels = Label != null ? Label : new [] {Title},
 				ChartBorderColor = ChartBorderColor?.Select(m => m.HtmlColor).ToArray(),

--- a/src/UniversalDashboard/Cmdlets/NewLinkCommand.cs
+++ b/src/UniversalDashboard/Cmdlets/NewLinkCommand.cs
@@ -11,7 +11,7 @@ namespace UniversalDashboard.Cmdlets
     {
 		private readonly Logger Log = LogManager.GetLogger(nameof(NewLinkCommand));
 
-		[Parameter(Mandatory = true)]
+		[Parameter()]
 		public string Text { get; set; }
 	    [Parameter(Mandatory = true)]
 		public string Url { get; set; }

--- a/src/UniversalDashboard/Help/New-UDChart.md
+++ b/src/UniversalDashboard/Help/New-UDChart.md
@@ -13,8 +13,8 @@ Creates a new chart.
 ## SYNTAX
 
 ```
-New-UDChart [-Labels <String[]>] [-Type <ChartType>] [-Title <String>] [-Options <Hashtable>]
- [-BackgroundColor <DashboardColor>] [-FontColor <DashboardColor>] [-Links <Link[]>]
+New-UDChart [-Labels <String[]>] [-Type <ChartType>] [-Title <String>] [-Options <Hashtable>] [-Width <String>]
+ [-Height <String>] [-BackgroundColor <DashboardColor>] [-FontColor <DashboardColor>] [-Links <Link[]>]
  [-FilterFields <ScriptBlock>] [-Endpoint <ScriptBlock>] [-ArgumentList <Object[]>] [-AutoRefresh]
  [-RefreshInterval <Int32>] [-Id <String>] [<CommonParameters>]
 ```
@@ -140,6 +140,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Height
+Set monitor custom height, you can use px,vw,%
+You can NOT use this parameter without width parameter.
+If you do you will get an error.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Id
 The ID of the chart. This ID is set on the HTML markup and is also used to identify the endpoint. 
 
@@ -238,6 +255,22 @@ Type: ChartType
 Parameter Sets: (All)
 Aliases:
 Accepted values: Bar, Line, Area, Doughnut, Radar, Pie
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Width
+Set monitor custom width, you can use px,vw,%
+You can use only width without the height parameter.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/src/UniversalDashboard/Help/New-UDLink.md
+++ b/src/UniversalDashboard/Help/New-UDLink.md
@@ -13,7 +13,7 @@ Creates an HTML link.
 ## SYNTAX
 
 ```
-New-UDLink -Text <String> -Url <String> [-Icon <FontAwesomeIcons>] [-OpenInNewWindow]
+New-UDLink [-Text <String>] -Url <String> [-Icon <FontAwesomeIcons>] [-OpenInNewWindow]
  [-FontColor <DashboardColor>] [<CommonParameters>]
 ```
 
@@ -85,7 +85,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/src/UniversalDashboard/Help/New-UDMonitor.md
+++ b/src/UniversalDashboard/Help/New-UDMonitor.md
@@ -15,9 +15,10 @@ Creates a live updating chart that shows a single type of data on a running time
 ```
 New-UDMonitor [-Type <ChartType>] -Title <String> [-DataPointHistory <Int32>] [-Options <Hashtable>]
  [-ChartBackgroundColor <DashboardColor[]>] [-ChartBorderColor <DashboardColor[]>]
- [-BackgroundColor <DashboardColor>] [-FontColor <DashboardColor>] [-BorderWidth <Int32>] [-Label <String[]>]
- [-Links <Link[]>] [-FilterFields <ScriptBlock>] [-Endpoint <ScriptBlock>] [-ArgumentList <Object[]>]
- [-AutoRefresh] [-RefreshInterval <Int32>] [-Id <String>] [<CommonParameters>]
+ [-BackgroundColor <DashboardColor>] [-Width <String>] [-Height <String>] [-FontColor <DashboardColor>]
+ [-BorderWidth <Int32>] [-Label <String[]>] [-Links <Link[]>] [-FilterFields <ScriptBlock>]
+ [-Endpoint <ScriptBlock>] [-ArgumentList <Object[]>] [-AutoRefresh] [-RefreshInterval <Int32>] [-Id <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -186,6 +187,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Height
+Set monitor custom height, you can use px,vw,%
+You can NOT use this parameter without width parameter.
+If you do you will get an error.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Id
 The HTML ID and endpoint ID for this component.
 
@@ -282,6 +300,22 @@ Type: ChartType
 Parameter Sets: (All)
 Aliases:
 Accepted values: Bar, Line, Area, Doughnut, Radar, Pie
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Width
+Set monitor custom width, you can use px,vw,%
+You can use only width without the height parameter.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/src/UniversalDashboard/Help/Out-UDGridData.md
+++ b/src/UniversalDashboard/Help/Out-UDGridData.md
@@ -13,7 +13,7 @@ Outputs data in a format that the jQuery DataTables grid will support.
 ## SYNTAX
 
 ```
-Out-UDGridData [[-Data] <Object>] [[-TotalItems] <Int32> [-Depth] <Int32>]]  [<CommonParameters>]
+Out-UDGridData [[-Data] <Object>] [[-TotalItems] <Int32>] [[-Depth] <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -47,19 +47,6 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -TotalItems
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Depth
 The maximum object depth to serialize.
 
@@ -70,6 +57,19 @@ Aliases:
 
 Required: False
 Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TotalItems
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/src/UniversalDashboard/Models/Chart.cs
+++ b/src/UniversalDashboard/Models/Chart.cs
@@ -14,6 +14,10 @@ namespace UniversalDashboard.Models
 		public string Title { get; set; }
 		[JsonProperty("options")]
 		public Hashtable Options { get; set; }
+		[JsonProperty("width")]
+		public string Width { get; set; }
+		[JsonProperty("height")]
+		public string Height { get; set; }
 		[JsonProperty("live")]
 		public bool Live { get; set; }
 		[JsonProperty("dataPointRetention")]

--- a/src/UniversalDashboard/Models/Monitor.cs
+++ b/src/UniversalDashboard/Models/Monitor.cs
@@ -8,6 +8,10 @@ namespace UniversalDashboard.Models
       public new string[] ChartBackgroundColor { get; set; }
       [JsonProperty("chartBorderColor")]
       public new string[] ChartBorderColor { get; set; }
+      [JsonProperty("width")]
+      public new string Width { get; set; }
+      [JsonProperty("height")]
+      public new string Height { get; set; }
 
       [JsonProperty("type")]
       public new string Type => "Monitor";

--- a/src/client/.babelrc
+++ b/src/client/.babelrc
@@ -1,3 +1,3 @@
 {
-    "presets" : ["es2015",  "stage-2", "react"]
+    "presets" : ["@babel/preset-react","@babel/preset-env"]
   }

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -28,7 +28,7 @@
     "numeral": "2.0.6",
     "promise-polyfill": "6.0.2",
     "pubsub-js": "1.5.7",
-    "react": "^16.4.2",
+    "react": "16.5.2",
     "react-chartjs-2": "2.6.2",
     "react-color": "2.13.8",
     "react-debounce-input": "3.2.0",
@@ -43,17 +43,19 @@
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-2": "6.24.1",
+    "@babel/core": "7.1.2",
+    "@babel/polyfill": "^7.0.0",
+    "@babel/preset-env": "7.1.0",
+    "@babel/preset-react": "7.0.0",
+    "babel-loader": "8.0.4",
     "css-loader": "^0.28.7",
-    "file-loader": "^0.11.2",
-    "html-webpack-plugin": "2.30.1",
-    "style-loader": "^0.18.2",
-    "uglifyjs-webpack-plugin": "0.4.6",
-    "webpack": "^3.6.0",
+    "file-loader": "2.0.0",
+    "html-webpack-plugin": "3.2.0",
+    "style-loader": "0.23.1",
+    "uglifyjs-webpack-plugin": "2.0.1",
+    "extract-text-webpack-plugin": "3.0.2",
+    "webpack": "4.21.0",
+    "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^2.8.2"
   }
 }

--- a/src/client/src/app/ud-chart.jsx
+++ b/src/client/src/app/ud-chart.jsx
@@ -89,7 +89,7 @@ export default class UdChart extends React.Component {
     }
 
     renderBar() {
-        return <Bar data={this.state.chartData} options={this.props.options} />
+        return <Bar  data={this.state.chartData} options={this.props.options}/>
     }
 
     renderLine() {
@@ -119,6 +119,40 @@ export default class UdChart extends React.Component {
             fields = <Row>{fields}</Row>
         }
         
+        if(this.props.width !== null && this.props.height !== null){
+            var cardStyle = {
+                background:this.props.backgroundColor,
+                color:this.props.fontColor,
+                width:this.props.width,
+                height:this.props.height,
+                marginBottom:'3rem'
+            }
+            this.props.options = {
+                maintainAspectRatio: false,
+                layout:{
+                    padding:{
+                        bottom:25
+                    }
+                }
+            }
+
+        }
+        else if(this.props.width !== null && this.props.height === null){
+            var cardStyle = {
+                background:this.props.backgroundColor,
+                color:this.props.fontColor,
+                width:this.props.width,
+            }
+        }
+        else if(this.props.width === null && this.props.height !== null){
+            return [<ErrorCard message={'Width property is missing'} key={this.props.id} id={this.props.id} title={this.props.title}/>, <ReactInterval timeout={this.props.refreshInterval * 1000} enabled={this.props.autoRefresh} callback={this.loadData.bind(this)}/>]
+        }
+        else{
+            var cardStyle = {
+                background:this.props.backgroundColor,
+                color:this.props.fontColor,
+            }
+        }
 
         var chart = null;
         if (this.state.chartData != null) {
@@ -160,39 +194,14 @@ export default class UdChart extends React.Component {
             </div>
         }
 
-        if(this.props.width !== null && this.props.height !== null){
-            var cardStyle = {
-                background:this.props.backgroundColor,
-                color:this.props.fontColor,
-                width:`${this.props.width}px`,
-                height:`${this.props.height}px`
-            }
-        }
-        else if(this.props.width !== null && this.props.height === null){
-            var cardStyle = {
-                background:this.props.backgroundColor,
-                color:this.props.fontColor,
-                width:`${this.props.width}px`,
-            }
-        }
-        else if(this.props.width === null && this.props.height !== null){
-            return [<ErrorCard message={'Width property is missing'} key={this.props.id} id={this.props.id} title={this.props.title}/>, <ReactInterval timeout={this.props.refreshInterval * 1000} enabled={this.props.autoRefresh} callback={this.loadData.bind(this)}/>]
-        }
-        else{
-            var cardStyle = {
-                background:this.props.backgroundColor,
-                color:this.props.fontColor,
-            }
-        }
-
-        return <div className="card ud-chart" key={this.props.id} id={this.props.id} style={{...cardStyle}}>
-                    <div className="card-content">
+        return <div className="card ud-chart" key={this.props.id} id={this.props.id} style={{background:cardStyle.background,color:cardStyle.color,marginBottom:cardStyle.marginBottom}}>
+                    <div className="card-content" style={{width:cardStyle.width,height:cardStyle.height}}>
                         <span className="card-title">{this.props.title}</span>
                         {chart}
                         {fields}
                         <ReactInterval timeout={this.props.refreshInterval * 1000} enabled={this.props.autoRefresh} callback={this.loadData.bind(this)}/>
                     </div>
-                    {actions}
+                        {actions}
                 </div>
     }
 }

--- a/src/client/src/app/ud-chart.jsx
+++ b/src/client/src/app/ud-chart.jsx
@@ -68,7 +68,9 @@ export default class UdChart extends React.Component {
                         errorMessage: json.error.message
                     })
                 } else {
-                    this.setState({chartData: json});
+                    this.setState({
+                        chartData: json
+                    });
                 }
             }.bind(this));
     }
@@ -79,15 +81,15 @@ export default class UdChart extends React.Component {
     }
     
     renderArea() {
-        return <Polar data={this.state.chartData} options={this.props.options}/>
+            return <Polar data={this.state.chartData} options={this.props.options}/>
     }
 
     renderDoughnut() {
-        return <Doughnut data={this.state.chartData} options={this.props.options}/>
+            return <Doughnut data={this.state.chartData} options={this.props.options}/>
     }
 
     renderBar() {
-        return <Bar data={this.state.chartData} options={this.props.options}/>
+        return <Bar data={this.state.chartData} options={this.props.options} />
     }
 
     renderLine() {
@@ -158,7 +160,32 @@ export default class UdChart extends React.Component {
             </div>
         }
 
-        return <div className="card ud-chart" key={this.props.id} id={this.props.id} style={{background: this.props.backgroundColor, color: this.props.fontColor}}>
+        if(this.props.width !== null && this.props.height !== null){
+            var cardStyle = {
+                background:this.props.backgroundColor,
+                color:this.props.fontColor,
+                width:`${this.props.width}px`,
+                height:`${this.props.height}px`
+            }
+        }
+        else if(this.props.width !== null && this.props.height === null){
+            var cardStyle = {
+                background:this.props.backgroundColor,
+                color:this.props.fontColor,
+                width:`${this.props.width}px`,
+            }
+        }
+        else if(this.props.width === null && this.props.height !== null){
+            return [<ErrorCard message={'Width property is missing'} key={this.props.id} id={this.props.id} title={this.props.title}/>, <ReactInterval timeout={this.props.refreshInterval * 1000} enabled={this.props.autoRefresh} callback={this.loadData.bind(this)}/>]
+        }
+        else{
+            var cardStyle = {
+                background:this.props.backgroundColor,
+                color:this.props.fontColor,
+            }
+        }
+
+        return <div className="card ud-chart" key={this.props.id} id={this.props.id} style={{...cardStyle}}>
                     <div className="card-content">
                         <span className="card-title">{this.props.title}</span>
                         {chart}

--- a/src/client/src/app/ud-monitor.jsx
+++ b/src/client/src/app/ud-monitor.jsx
@@ -206,7 +206,41 @@ export default class UdMonitor extends React.Component {
                             display: true
                         }
                     }]
-                }
+                },
+                layout:{
+                    padding:{
+                        bottom:25
+                    }
+                },
+                maintainAspectRatio: true
+            }
+
+        }
+
+        if(this.props.width !== null && this.props.height !== null){
+            var cardStyle = {
+                background:this.props.backgroundColor,
+                color:this.props.fontColor,
+                width:this.props.width,
+                height:this.props.height,
+                marginBottom:'3rem'
+            }
+            options.maintainAspectRatio = false
+        }
+        else if(this.props.width !== null && this.props.height === null){
+            var cardStyle = {
+                background:this.props.backgroundColor,
+                color:this.props.fontColor,
+                width:this.props.width,
+            }
+        }
+        else if(this.props.width === null && this.props.height !== null){
+            return [<ErrorCard message={'Width property is missing'} key={this.props.id} id={this.props.id} title={this.props.title}/>, <ReactInterval timeout={this.props.refreshInterval * 1000} enabled={this.props.autoRefresh} callback={this.loadData.bind(this)}/>]
+        }
+        else{
+            var cardStyle = {
+                background:this.props.backgroundColor,
+                color:this.props.fontColor,
             }
         }
 
@@ -244,8 +278,8 @@ export default class UdMonitor extends React.Component {
             </div>
         }
         
-        return <div className="card ud-monitor" id={this.props.id} key={this.props.id} style={{background: this.props.backgroundColor, color: this.props.fontColor}}>
-                    <div className="card-content">
+        return <div className="card ud-monitor" id={this.props.id} key={this.props.id} style={{background:cardStyle.background,color:cardStyle.color,marginBottom:cardStyle.marginBottom}}>
+                    <div className="card-content" style={{width:cardStyle.width,height:cardStyle.height}}>
                         <span className="card-title">{this.props.title}</span>
                         {chart}
                         {fields}

--- a/src/client/src/app/ud-navbar.jsx
+++ b/src/client/src/app/ud-navbar.jsx
@@ -44,7 +44,7 @@ export default class UdNavbar extends React.Component {
                     {
                         this.props.authenticated ?
                         <a href="#!" onClick={this.signOut.bind(this)} className="right" style={{paddingRight: '10px'}} id="signoutLink"><span>Sign Out</span></a> :
-                        <div/>
+                        <React.Fragment/>
                     }
                     <ul id="nav-mobile" className="right hide-on-med-and-down">
                         {links}

--- a/src/client/webpack.config.js
+++ b/src/client/webpack.config.js
@@ -19,10 +19,10 @@ module.exports = (env) => {
       publicPath: "/"
     },
     module : {
-      loaders : [
+      rules : [
         { test: /\.css$/, loader: "style-loader!css-loader" },
         { test: /\.(js|jsx)$/, exclude: [/node_modules/, /public/], loader: 'babel-loader'},
-        { test: /\.(eot|ttf|woff2?|otf|svg)$/, loaders: ['file-loader'] }
+        { test: /\.(eot|ttf|woff2?|otf|svg)$/, loader:'file-loader' }
       ]
     },
     resolve: {
@@ -32,17 +32,19 @@ module.exports = (env) => {
       extensions: ['.json', '.js', '.jsx']
     },
     plugins: [
-      new HtmlWebpackPlugin({
-        template: path.resolve(SRC_DIR, 'index.html'),
-        chunksSortMode: 'dependency'
-      })
-    ].concat(!isDev?[    new UglifyJSPlugin({
-        compress: {
-          warnings: false
-        },
-        sourceMap: true
-      })]:[])
-      ,
+            new HtmlWebpackPlugin({
+              template: path.resolve(SRC_DIR, 'index.html'),
+              chunksSortMode: 'dependency'
+            }),
+            new UglifyJSPlugin({
+              uglifyOptions:{
+                compress: {
+                  warnings: false
+                },
+                sourceMap: true
+              }
+            })
+    ],
     devtool: 'source-map',
     devServer: {
       historyApiFallback: true,

--- a/src/poshud/pages/chart-updated.ps1
+++ b/src/poshud/pages/chart-updated.ps1
@@ -1,0 +1,79 @@
+New-UDPage -Name demo -Content {
+
+    # Main Chart full width custom height.
+    new-udrow -Columns {
+        New-UDChart -Title "Feature by operating system" -Type Line -AutoRefresh -RefreshInterval 7 @Colors -Endpoint {
+            $features = @();
+            $features += [PSCustomObject]@{ "OperatingSystem" = "Windows 10"; "FormsDesigner" = (Get-Random -Minimum 10 -Maximum 10000);  "WPFDesigner" = (Get-Random -Minimum 10 -Maximum 10000);  "UniversalDashboard" = (Get-Random -Minimum 10 -Maximum 10000) }
+            $features += [PSCustomObject]@{ "OperatingSystem" = "Windows 8"; "FormsDesigner" = (Get-Random -Minimum 10 -Maximum 10000);  "WPFDesigner" = (Get-Random -Minimum 10 -Maximum 10000);  "UniversalDashboard" = (Get-Random -Minimum 10 -Maximum 10000) }
+            $features += [PSCustomObject]@{ "OperatingSystem" = "Windows 7"; "FormsDesigner" = (Get-Random -Minimum 10 -Maximum 10000);  "WPFDesigner" = (Get-Random -Minimum 10 -Maximum 10000);  "UniversalDashboard" = (Get-Random -Minimum 10 -Maximum 10000) }
+            $features += [PSCustomObject]@{ "OperatingSystem" = "Ubuntu 16.04"; "FormsDesigner" = (Get-Random -Minimum 10 -Maximum 10000);  "WPFDesigner" = (Get-Random -Minimum 10 -Maximum 10000);  "UniversalDashboard" = (Get-Random -Minimum 10 -Maximum 10000) }
+            $features| Out-UDChartData -LabelProperty "OperatingSystem" -Dataset @(
+                New-UDChartDataset -DataProperty "FormsDesigner" -Label "Forms Designer" -BackgroundColor "#0288d1" -HoverBackgroundColor "#0d47a1" -BorderColor '#01579b' 
+                New-UDChartDataset -DataProperty "WPFDesigner" -Label "WPF Designer" -BackgroundColor "#00b0ff" -HoverBackgroundColor "#fff" -BorderColor '#01579b'
+                New-UDChartDataset -DataProperty "UniversalDashboard" -Label "Universal Dashboard" -BackgroundColor "#4fc3f7" -HoverBackgroundColor "#004d40" -BorderColor '#01579b'
+            ) 
+        } -Width 99vw -Height 560px -Links @(
+            New-UDLink -Icon github_alt -Url 'https://github.com' -Text GitHub -FontColor '#0277bd'
+        )
+    }
+
+    # Second line custom width from chart & monitor.
+    new-udrow -Columns {
+        new-udcolumn -Content {
+            New-UDChart -Title "Demo" -Type Line -Endpoint {
+                20..0 | ForEach-Object {
+                    [PSCustomObject]@{ 
+                        Minute = " -$_"
+                        PacketsPerSecond = (Get-Random -Minimum 50000 -Maximum 250000)
+                    }
+                } | Out-UDChartData -LabelProperty "Minute" -DataProperty "PacketsPerSecond" -DatasetLabel "Packets per second" -BackgroundColor "#0277bd" -BorderColor "#03a9f4" -HoverBackgroundColor "#b3e5fc" -HoverBorderColor "#03a9f4"
+            } -BackgroundColor "#252525" -FontColor "#FFFFFF" -Width 48.5vw
+        }
+
+        new-udcolumn -Content {
+            New-UDMonitor -Title "Downloads per second" -Type Line  -Endpoint {
+                Get-Random -Minimum 0 -Maximum 10 | Out-UDMonitorData
+            } -DataPointHistory 20 -RefreshInterval 5 -Width 48.5vw -ChartBackgroundColor "#0277bd" -ChartBorderColor "#03a9f4" -BackgroundColor "#252525"
+        } 
+    }
+
+    # Third line custom chart & monitor with width and height 
+    New-UDRow -Columns {
+        New-UDColumn  -Content {
+            New-UDChart -Title "Demo" -Type Bar -Endpoint {
+                5..0 | ForEach-Object {
+                    [PSCustomObject]@{ 
+                        Minute = " -$_"
+                        PacketsPerSecond = (Get-Random -Minimum 50000 -Maximum 250000)
+                    }
+                } | Out-UDChartData -LabelProperty "Minute" -DataProperty "PacketsPerSecond" -DatasetLabel "Packets per second" -BackgroundColor "#0277bd" -BorderColor "#03a9f4" -HoverBackgroundColor "#b3e5fc" -HoverBorderColor "#03a9f4"
+            } -BackgroundColor "#252525" -FontColor "#FFFFFF" -Width 16vw -Height 300px -Links @(
+
+                New-UDlink -Url 'https://github.com/ironmansoftware/universal-dashboard' -Icon github -FontColor '#0277bd'
+                New-UDlink -Url 'https://github.com/ironmansoftware/universal-dashboard' -Icon code_fork -FontColor '#0277bd'
+                New-UDlink -Url 'https://github.com/ironmansoftware/universal-dashboard' -Icon book -FontColor '#0277bd'
+                New-UDlink -Url 'https://github.com/ironmansoftware/universal-dashboard' -Icon comments -FontColor '#0277bd'
+
+            )
+        }
+        New-UDColumn -Content {
+            New-UDChart -Title "Demo" -Type Bar -Endpoint {
+                10..0 | ForEach-Object {
+                    [PSCustomObject]@{ 
+                        Minute = " -$_"
+                        PacketsPerSecond = (Get-Random -Minimum 50000 -Maximum 250000)
+                    }
+                } | Out-UDChartData -LabelProperty "Minute" -DataProperty "PacketsPerSecond" -DatasetLabel "Packets per second" -BackgroundColor "#0277bd" -BorderColor "#03a9f4" -HoverBackgroundColor "#b3e5fc" -HoverBorderColor "#03a9f4"
+            } -BackgroundColor "#252525" -FontColor "#FFFFFF" -Width 30vw -Height 300px
+        }
+        New-UDColumn -Content {
+            New-UDMonitor -Title "Downloads per second" -Type Line  -Endpoint {
+                Get-Random -Minimum 0 -Maximum 10 | Out-UDMonitorData
+            } -DataPointHistory 20 -RefreshInterval 5 -Width 50vw -Height 300px -ChartBackgroundColor "#0277bd" -ChartBorderColor "#03a9f4" -BackgroundColor "#252525" -Links @(
+                New-UDLink -Icon github_alt -Url 'https://github.com' 
+            ) -FontColor '#ffffff'
+        }
+    }
+
+}

--- a/src/poshud/pages/charts.ps1
+++ b/src/poshud/pages/charts.ps1
@@ -36,6 +36,7 @@ $CustomColors = {
 }
 
 
+
 $MultiDatasetChart = {
     New-UDChart -Title "Feature by operating system" -Type Line -AutoRefresh -RefreshInterval 7 @Colors -Endpoint {
         $features = @();


### PR DESCRIPTION
Add 2 new properties for chart and monitor: Width & Height

You can use those parameter with values like 300px, 80vw, 100%

Preview
![image](https://user-images.githubusercontent.com/34351424/47251215-f432e280-d439-11e8-8ea4-b3b0ce7071df.png)

![image](https://user-images.githubusercontent.com/34351424/47251220-0745b280-d43a-11e8-8bb3-fb68d04da1b9.png)

And i add new test for custom chart size, and update the help for the new parameters.