### PR TITLE
Update UniversalDashboardServer.psm1

### DIFF
--- a/src/UniversalDashboard/UniversalDashboardServer.psm1
+++ b/src/UniversalDashboard/UniversalDashboardServer.psm1
@@ -1339,7 +1339,7 @@ function New-UDDoughnutChartDataset {
 		[int[]]$HoverBorderWidth
 	)
 
-	$obj = [PSCustomObject]@{
+	$obj = @{
 		data = @()
 	}
 


### PR DESCRIPTION
Modify New-UDDoughnutChartDataset function in UniversalDashboardServer.psm1. Remove [PSCustomObject] to avoid error "Unable to index into an object of type System.Management.Automation.PSObject" when creating New-UDDoughnutChartDataset.