### PR TITLE
Updated documentation links from https://adamdriscoll.gitbooks.io to …

### DIFF
--- a/examples/azure-dashboard.ps1
+++ b/examples/azure-dashboard.ps1
@@ -4,10 +4,10 @@ $Colors = @{
 }
 
 $NavBarLinks = @((New-UDLink -Text "<i class='material-icons' style='display:inline;padding-right:5px'>favorite_border</i> PowerShell Pro Tools" -Url "https://poshtools.com/buy-powershell-pro-tools/"),
-                 (New-UDLink -Text "<i class='material-icons' style='display:inline;padding-right:5px'>description</i> Documentation" -Url "https://adamdriscoll.gitbooks.io/powershell-tools-documentation/content/powershell-pro-tools-documentation/about-universal-dashboard.html"))
+                 (New-UDLink -Text "<i class='material-icons' style='display:inline;padding-right:5px'>description</i> Documentation" -Url "https://docs.universaldashboard.io/"))
 
-Start-UDDashboard -Wait -Content { 
-    New-UDDashboard -NavbarLinks $NavBarLinks -Title "PowerShell Pro Tools Universal Dashboard" -NavBarColor '#FF1c1c1c' -NavBarFontColor "#FF55b3ff" -BackgroundColor "#FF333333" -FontColor "#FFFFFFF" -Content { 
+Start-UDDashboard -Wait -Content {
+    New-UDDashboard -NavbarLinks $NavBarLinks -Title "PowerShell Pro Tools Universal Dashboard" -NavBarColor '#FF1c1c1c' -NavBarFontColor "#FF55b3ff" -BackgroundColor "#FF333333" -FontColor "#FFFFFFF" -Content {
         New-UDRow {
             New-UDColumn -Size 3 {
                 New-UDHtml -Markup "<div class='card' style='background: rgba(37, 37, 37, 1); color: rgba(255, 255, 255, 1)'><div class='card-content'><span class='card-title'>About Universal Dashboard</span><p>Universal Dashboard is a cross-platform PowerShell module used to design beautiful dashboards from any available dataset. Visit GitHub to see some example dashboards.</p></div><div class='card-action'><a href='https://www.github.com/adamdriscoll/poshprotools'>GitHub</a></div></div>"
@@ -15,17 +15,17 @@ Start-UDDashboard -Wait -Content {
             New-UDColumn -Size 3 {
                 New-UDMonitor -Title "Users per second" -Type Line -DataPointHistory 20 -RefreshInterval 15 -ChartBackgroundColor '#5955FF90' -ChartBorderColor '#FF55FF90' @Colors -Endpoint {
                     Get-Random -Minimum 0 -Maximum 100 | Out-UDMonitorData
-                } 
+                }
             }
             New-UDColumn -Size 3 {
                 New-UDMonitor -Title "Downloads per second" -Type Line -DataPointHistory 20 -RefreshInterval 5 -ChartBackgroundColor '#59FF681B' -ChartBorderColor '#FFFF681B' @Colors -Endpoint {
                     Get-Random -Minimum 0 -Maximum 10 | Out-UDMonitorData
-                } 
+                }
             }
             New-UDColumn -Size 3 {
                 New-UDMonitor -Title "Tweets per second" -Type Line -DataPointHistory 20 -RefreshInterval 20 -ChartBackgroundColor '#595479FF' -ChartBorderColor '#FF5479FF' @Colors -Endpoint {
                     Get-Random -Minimum 0 -Maximum 10000 | Out-UDMonitorData
-                } 
+                }
             }
         }
         New-UDRow {
@@ -50,13 +50,13 @@ Start-UDDashboard -Wait -Content {
                     $issues += [PSCustomObject]@{ "ID" = (Get-Random -Minimum 10 -Maximum 10000);  "Title" = "Support for running on a PS4";  "Description" = "A dashboard on a PS4 would be pretty cool."; Comments = (Get-Random -Minimum 10 -Maximum 10000) }
                     $issues += [PSCustomObject]@{ "ID" = (Get-Random -Minimum 10 -Maximum 10000);  "Title" = "Bug in the flux capacitor";  "Description" = "The flux capacitor is constantly crashing."; Comments = (Get-Random -Minimum 10 -Maximum 10000) }
                     $issues += [PSCustomObject]@{ "ID" = (Get-Random -Minimum 10 -Maximum 10000);  "Title" = "Feature Request - Hypnotoad Widget";  "Description" = "Every dashboard needs more hypnotoad"; Comments = (Get-Random -Minimum 10 -Maximum 10000) }
-                    
+
                     $issues | Out-UDGridData
                 }
             }
         }
     }
-} 
+}
 
 Start-Process http://localhost
- 
+

--- a/examples/poshud.ps1
+++ b/examples/poshud.ps1
@@ -14,7 +14,7 @@ $ScriptColors = @{
 }
 
 $NavBarLinks = @((New-UDLink -Text "Buy Universal Dashboard" -Url "https://poshtools.com/buy-powershell-pro-tools/" -Icon heart_o),
-                 (New-UDLink -Text "Documentation" -Url "https://adamdriscoll.gitbooks.io/powershell-tools-documentation/content/powershell-pro-tools-documentation/universal-dashboard.html" -Icon book))
+                 (New-UDLink -Text "Documentation" -Url "https://docs.universaldashboard.io/" -Icon book))
 
 $Components = New-UDPage -Name Components -Icon area_chart -Content {
     New-UDHtml -Markup '<link rel="stylesheet"
@@ -98,17 +98,17 @@ $Components = New-UDPage -Name Components -Icon area_chart -Content {
         New-UDColumn -Size 4 {
             New-UDMonitor -Title "Downloads per second" -Type Line -DataPointHistory 20 -RefreshInterval 5 -ChartBackgroundColor '#59FF681B' -ChartBorderColor '#FFFF681B' @Colors -Endpoint {
                 Get-Random -Minimum 0 -Maximum 10 | Out-UDMonitorData
-            } 
+            }
         }
         New-UDColumn -Size 4 {
             New-UDMonitor -Title "Tweets per second" -Type Line -DataPointHistory 20 -RefreshInterval 20 -ChartBackgroundColor '#595479FF' -ChartBorderColor '#FF5479FF' @Colors -Endpoint {
                 Get-Random -Minimum 0 -Maximum 10000 | Out-UDMonitorData
-            } 
+            }
         }
         New-UDColumn -Size 4 {
             New-UDMonitor -Title "Visits per second" -Type Line -DataPointHistory 20 -RefreshInterval 20 -ChartBackgroundColor '#591179FF' -ChartBorderColor '#FF1279FF' @Colors -Endpoint {
                 Get-Random -Minimum 0 -Maximum 10000 | Out-UDMonitorData
-            } 
+            }
         }
     }
     New-UDRow {
@@ -125,17 +125,17 @@ $Components = New-UDPage -Name Components -Icon area_chart -Content {
         New-UDColumn -Size 4 {
             New-UDCounter -Title "Total Bytes Downloaded" -AutoRefresh -RefreshInterval 3 -Format '0.00b' -Icon cloud_download @Colors -Endpoint {
                 Get-Random -Minimum 0 -Maximum 100000000 | ConvertTo-Json
-            } 
+            }
         }
         New-UDColumn -Size 4 {
             New-UDCounter -Title "Total Bytes Uploaded" -AutoRefresh -RefreshInterval 3 -Format '0.00b' -Icon cloud_upload @Colors -Endpoint {
                 Get-Random -Minimum 0 -Maximum 100000000 | ConvertTo-Json
-            } 
+            }
         }
         New-UDColumn -Size 4 {
             New-UDCounter -Title "Total Revenue" -AutoRefresh -RefreshInterval 3 -Format '$0,0.00' -Icon money @Colors -Endpoint {
                 Get-Random -Minimum 0 -Maximum 100000000 | ConvertTo-Json
-            } 
+            }
         }
     }
     New-UDRow {
@@ -151,7 +151,7 @@ $Components = New-UDPage -Name Components -Icon area_chart -Content {
     New-UDRow {
         New-UDColumn -Size 12 {
             New-UDGrid -Title "Customer Locations" @Colors -Headers @("Country", "Customers", "First Purchase Date") -Properties @("Country", "Customers", "FirstPurchaseDate") -AutoRefresh -RefreshInterval 20 -Endpoint {
-                
+
                                      @(
                                             @{
                                                     Country = "MAURITANIA"
@@ -253,7 +253,7 @@ $Components = New-UDPage -Name Components -Icon area_chart -Content {
                                                     Customers = 377
                                                     FirstPurchaseDate = "4/22/2017"
                                                 }
-                
+
                                              )  | Out-UDGridData
                                 }
         }
@@ -269,8 +269,8 @@ $Components = New-UDPage -Name Components -Icon area_chart -Content {
     $issues += [PSCustomObject]@{ "ID" = (Get-Random -Minimum 10 -Maximum 10000);  "Title" = "Support for running on a PS4";  "Description" = "A dashboard on a PS4 would be pretty cool."; Comments = (Get-Random -Minimum 10 -Maximum 10000) }
     $issues += [PSCustomObject]@{ "ID" = (Get-Random -Minimum 10 -Maximum 10000);  "Title" = "Bug in the flux capacitor";  "Description" = "The flux capacitor is constantly crashing."; Comments = (Get-Random -Minimum 10 -Maximum 10000) }
     $issues += [PSCustomObject]@{ "ID" = (Get-Random -Minimum 10 -Maximum 10000);  "Title" = "Feature Request - Hypnotoad Widget";  "Description" = "Every dashboard needs more hypnotoad"; Comments = (Get-Random -Minimum 10 -Maximum 10000) }
-    
-    $issues | Out-UDTableData -Property @("ID", "Title", "Description", "Comments") 
+
+    $issues | Out-UDTableData -Property @("ID", "Title", "Description", "Comments")
 }' -Title "PowerShell"
         }
 
@@ -283,8 +283,8 @@ $Components = New-UDPage -Name Components -Icon area_chart -Content {
                 $issues += [PSCustomObject]@{ "ID" = (Get-Random -Minimum 10 -Maximum 10000);  "Title" = "Support for running on a PS4";  "Description" = "A dashboard on a PS4 would be pretty cool."; Comments = (Get-Random -Minimum 10 -Maximum 10000) }
                 $issues += [PSCustomObject]@{ "ID" = (Get-Random -Minimum 10 -Maximum 10000);  "Title" = "Bug in the flux capacitor";  "Description" = "The flux capacitor is constantly crashing."; Comments = (Get-Random -Minimum 10 -Maximum 10000) }
                 $issues += [PSCustomObject]@{ "ID" = (Get-Random -Minimum 10 -Maximum 10000);  "Title" = "Feature Request - Hypnotoad Widget";  "Description" = "Every dashboard needs more hypnotoad"; Comments = (Get-Random -Minimum 10 -Maximum 10000) }
-                
-                $issues | Out-UDTableData -Property @("ID", "Title", "Description", "Comments") 
+
+                $issues | Out-UDTableData -Property @("ID", "Title", "Description", "Comments")
             }
         }
     }
@@ -366,12 +366,12 @@ $Formatting = New-UDPage -Name "Formatting" -Icon th {
         }
         New-UDColumn -Size 9 {
             New-UDCard @ScriptColors -Language "PowerShell" -Text 'New-UDLayout -Columns 3 -Content {
-    New-UDCard 
-    New-UDCard 
-    New-UDCard 
-    New-UDCard 
-    New-UDCard 
-    New-UDCard 
+    New-UDCard
+    New-UDCard
+    New-UDCard
+    New-UDCard
+    New-UDCard
+    New-UDCard
 }' -Title "PowerShell"
         }
     }
@@ -379,12 +379,12 @@ $Formatting = New-UDPage -Name "Formatting" -Icon th {
     New-UDRow {
         New-UDColumn -Size 12 {
             New-UDLayout -Columns 3 -Content {
-                New-UDCard 
                 New-UDCard
                 New-UDCard
-                New-UDCard 
-                New-UDCard 
-                New-UDCard 
+                New-UDCard
+                New-UDCard
+                New-UDCard
+                New-UDCard
             }
         }
     }
@@ -405,7 +405,7 @@ $Formatting = New-UDPage -Name "Formatting" -Icon th {
         }
         New-UDColumn -Size 9 {
             New-UDCard @ScriptColors -Language "PowerShell" -Text '$NavBarLinks = @((New-UDLink -Text "PowerShell Pro Tools" -Url "https://poshtools.com/buy-powershell-pro-tools/" -Icon heart_o),
-(New-UDLink -Text "Documentation" -Url "https://adamdriscoll.gitbooks.io/powershell-tools-documentation/content/powershell-pro-tools-documentation/universal-dashboard.html" -Icon book))
+(New-UDLink -Text "Documentation" -Url "https://docs.universaldashboard.io/" -Icon book))
 New-UDDashboard -NavbarLinks $NavBarLinks -Title "PowerShell Universal Dashboard" -NavBarColor "#FF1c1c1c" -NavBarFontColor "#FF55b3ff" -BackgroundColor "#FF333333" -FontColor "#FFFFFFF" ' -Title "PowerShell"
         }
     }
@@ -444,7 +444,7 @@ $HomePage = New-UDPage -Name "Home" -Icon home -Content {
         New-UDColumn -Size 4 {
             New-UDRow {
                 New-UDColumn -Size 12 {
-                    New-UDCard @Colors -Title "Modern Technology" -Text "Using PowerShell Core, Material Design, ReactJS and ASP.NET Core, Universal Dashboard takes advantage of cutting-edge technology to provide cross-platform, cross-device dashboards that looks sleek and modern." 
+                    New-UDCard @Colors -Title "Modern Technology" -Text "Using PowerShell Core, Material Design, ReactJS and ASP.NET Core, Universal Dashboard takes advantage of cutting-edge technology to provide cross-platform, cross-device dashboards that looks sleek and modern."
                 }
             }
             New-UDRow {
@@ -467,7 +467,7 @@ $HomePage = New-UDPage -Name "Home" -Icon home -Content {
         New-UDColumn -Size 4 {
             New-UDRow {
                 New-UDColumn -Size 12 {
-                    New-UDCard @Colors -Title "Written in PowerShell" -Text "Develop both the front-end interface and backend endpoints in the same PowerShell script. Host dashboards right from the console or in Azure\IIS."  -Links @(New-UDLink -Text "View this dashboard's PowerShell Script" -Url "https://github.com/adamdriscoll/poshprotools/blob/master/examples/universal-dashboard/azure-dashboard.ps1")
+                    New-UDCard @Colors -Title "Written in PowerShell" -Text "Develop both the front-end interface and backend endpoints in the same PowerShell script. Host dashboards right from the console or in Azure\IIS."  -Links @(New-UDLink -Text "View this dashboard's PowerShell Script" -Url "https://github.com/ironmansoftware/universal-dashboard/blob/master/examples/azure-dashboard.ps1")
                 }
             }
             New-UDRow {
@@ -479,10 +479,10 @@ $HomePage = New-UDPage -Name "Home" -Icon home -Content {
     }
 }
 
-Start-UDDashboard -Content { 
+Start-UDDashboard -Content {
     New-UDDashboard -NavbarLinks $NavBarLinks -Title "PowerShell Universal Dashboard" -NavBarColor '#FF1c1c1c' -NavBarFontColor "#FF55b3ff" -BackgroundColor "#FF333333" -FontColor "#FFFFFFF" -Pages @(
         $HomePage,
         $Components,
         $Formatting
-    ) 
+    )
 } -Port 10001 -Wait

--- a/src/poshud/pages/charts.ps1
+++ b/src/poshud/pages/charts.ps1
@@ -3,7 +3,7 @@ $BasicChart = {
 
         $30DaysBack = [DateTime]::Now.AddDays(-30)
         0..30 | ForEach-Object {
-            [PSCustomObject]@{ 
+            [PSCustomObject]@{
                 Date = $30DaysBack.AddDays($_).ToShortDateString()
                 Price = (Get-Random -Minimum 5000 -Maximum 20000)
             }
@@ -16,7 +16,7 @@ $AutoRefreshChart = {
 
         $30DaysBack = [DateTime]::Now.AddYears(-30)
         0..30 | ForEach-Object {
-            [PSCustomObject]@{ 
+            [PSCustomObject]@{
                 Year = $30DaysBack.AddDays($_).Year
                 Population = (Get-Random -Minimum 50000 -Maximum 250000)
             }
@@ -27,7 +27,7 @@ $AutoRefreshChart = {
 $CustomColors = {
     New-UDChart -Title "Packets per second" -Type Bar -Endpoint {
         30..0 | ForEach-Object {
-            [PSCustomObject]@{ 
+            [PSCustomObject]@{
                 Minute = " -$_"
                 PacketsPerSecond = (Get-Random -Minimum 50000 -Maximum 250000)
             }
@@ -53,7 +53,7 @@ $MultiDatasetChart = {
 }
 
 New-UDPage -Name "Charts" -Icon chart_area -Content {
-    New-UDPageHeader -Title "Charts" -Icon "area-chart" -Description "Visual data using dynamic charts based on ChartJS" -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/charts.html"
+    New-UDPageHeader -Title "Charts" -Icon "area-chart" -Description "Visual data using dynamic charts based on ChartJS" -DocLink "https://docs.universaldashboard.io/components/data-visualizations/charts"
     New-UDExample -Title "Basic Charts" -Description "Create basic charts from any type of data." -Script $BasicChart
     New-UDExample -Title "Auto Refreshing Charts" -Description "Automatically refresh chart data on an interval" -Script $AutoRefreshChart
     New-UDExample -Title "Custom colors" -Description "Adjust colors of different components within the chart." -Script $CustomColors

--- a/src/poshud/pages/counters.ps1
+++ b/src/poshud/pages/counters.ps1
@@ -17,7 +17,7 @@ $Formatting = {
 }
 
 New-UDPage -Name "Counters" -Icon sort_numeric_down -Content {
-    New-UDPageHeader -Title "Counters" -Icon "sort-numeric-asc" -Description "Show a simple count in a card." -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/api/1.5.0/New-UDCounter.html"
+    New-UDPageHeader -Title "Counters" -Icon "sort-numeric-asc" -Description "Show a simple count in a card." -DocLink "https://github.com/adamdriscoll/universal-dashboard-documentation/blob/master/api/1.5.0/New-UDCounter.md"
     New-UDExample -Title "Basic Counters" -Description "Display a basic number in a card" -Script $Basic
     New-UDExample -Title "Auto Refreshing Counters" -Description "Turn on auto refresh for the counter to refresh the count." -Script $AutoRefresh
     New-UDExample -Title "Format Numbers" -Description "Format numbers on the client using format strings." -Script $Formatting

--- a/src/poshud/pages/elements.ps1
+++ b/src/poshud/pages/elements.ps1
@@ -4,19 +4,19 @@ $CustomElement = {
 }
 
 $NestedElements = {
-    New-UDElement -Tag "div" -Attributes @{ className = "card black-text"} -Content { 
+    New-UDElement -Tag "div" -Attributes @{ className = "card black-text"} -Content {
         New-UDElement -Tag "div" -Attributes @{ className = "card-content" } -Content { "Nested Element!" }
      }
 }
 
 $Attributes = {
-    New-UDElement -Tag "div" -Attributes @{ 
+    New-UDElement -Tag "div" -Attributes @{
         className = "card"
         style = @{
             backgroundColor = "#4081C9"
             color = "#FFFFFF"
         }
-    } -Content { 
+    } -Content {
         "Attributes"
     }
 }
@@ -64,7 +64,7 @@ $ClearChildren = {
     }
 
     New-UDElement -Tag "a" -Attributes @{ className = "btn"; onClick = $onClickHandler } -Content { "Clear Children" }
-    New-UDElement -Tag "div" -Id "clearMe" -Attributes @{ className = "card black-text" } -Endpoint { 
+    New-UDElement -Tag "div" -Id "clearMe" -Attributes @{ className = "card black-text" } -Endpoint {
         New-UDElement -Tag "p" -Content { "Child1" }
         New-UDElement -Tag "p" -Content { "Child2" }
         New-UDElement -Tag "p" -Content { "Child3" }
@@ -72,7 +72,7 @@ $ClearChildren = {
 }
 
 New-UDPage -Name "Elements" -Icon cubes -Content {
-    New-UDPageHeader -Title "Elements" -Icon "cubes" -Description "Create custom elements using PowerShell script to create any type of HTML node. Take advantage of websockets to create real-time applications." -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/custom-elements.html"
+    New-UDPageHeader -Title "Elements" -Icon "cubes" -Description "Create custom elements using PowerShell script to create any type of HTML node. Take advantage of websockets to create real-time applications." -DocLink "https://docs.universaldashboard.io/components/custom-components/powershell-elements"
     New-UDExample -Title "Simple Elements" -Description "Simple HTML element." -Script $CustomElement
     New-UDExample -Title "Nested Elements" -Description "Elements can be nested within each other." -Script $NestedElements
     New-UDExample -Title "Attributes" -Description "Set attributes on the HTML tag." -Script $Attributes

--- a/src/poshud/pages/formatting.ps1
+++ b/src/poshud/pages/formatting.ps1
@@ -23,19 +23,19 @@ $Layout = {
     New-UDRow {
         New-UDColumn -Size 12 {
             New-UDLayout -Columns 3 -Content {
-                New-UDCard 
                 New-UDCard
                 New-UDCard
-                New-UDCard 
-                New-UDCard 
-                New-UDCard 
+                New-UDCard
+                New-UDCard
+                New-UDCard
+                New-UDCard
             }
         }
     }
 }
 
 New-UDPage -Name "Formatting" -Icon th {
-    New-UDPageHeader -Title "Formatting" -Icon "th" -Description "Control the layout of your website." -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/formatting.html"
+    New-UDPageHeader -Title "Formatting" -Icon "th" -Description "Control the layout of your website." -DocLink "https://docs.universaldashboard.io/components/formatting"
     New-UDExample -Title 'Row and column' -Description 'Organize elements by row and column.' -Script $GridSystem
     New-UDExample -Title 'Layouts' -Description 'Automaticaly generates rows and columns based on the number of child elements.' -Script $Layout
 }

--- a/src/poshud/pages/grids.ps1
+++ b/src/poshud/pages/grids.ps1
@@ -106,17 +106,17 @@ $GridData =     @(
 $Basic = {
     New-UDGrid -Title "Customer Locations"  -Headers @("Country", "Customers", "First Purchase Date") -Properties @("Country", "Customers", "FirstPurchaseDate") -Endpoint {
         $GridData | Out-UDGridData
-    } -FontColor "black"  
+    } -FontColor "black"
 }
 
 $AutoRefresh = {
     New-UDGrid -Title "Customer Locations"  -Headers @("Country", "Customers", "First Purchase Date") -Properties @("Country", "Customers", "FirstPurchaseDate") -Endpoint {
         $GridData | Out-UDGridData
-    } -AutoRefresh -RefreshInterval 5 -FontColor "black" 
+    } -AutoRefresh -RefreshInterval 5 -FontColor "black"
 }
 
 New-UDPage -Name "Grids" -Icon th_large -Content {
-    New-UDPageHeader -Title "Grids" -Icon "th-large" -Description "Display data in a grid that can sort, filter and page." -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/grids.html"
+    New-UDPageHeader -Title "Grids" -Icon "th-large" -Description "Display data in a grid that can sort, filter and page." -DocLink "https://docs.universaldashboard.io/components/grids"
     New-UDExample -Title "Basic Grids" -Description "A basic grid that displays data." -Script $Basic
     New-UDExample -Title "Auto Refreshing Grids" -Description "A grid that auto refreshes" -Script $AutoRefresh
 }

--- a/src/poshud/pages/images.ps1
+++ b/src/poshud/pages/images.ps1
@@ -4,6 +4,6 @@ $Image = {
 }
 
 New-UDPage -Name "Images" -Icon image -Content {
-    New-UDPageHeader -Title "Images" -Icon "image" -Description "Display images" -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/api/1.5.0/New-UDImage.html"
+    New-UDPageHeader -Title "Images" -Icon "image" -Description "Display images" -DocLink "https://github.com/adamdriscoll/universal-dashboard-documentation/blob/master/api/1.5.0/New-UDImage.md"
     New-UDExample -Title "Base64 Image" -Description "Embed base64 images in your dashboard." -Script $Image
 }

--- a/src/poshud/pages/inputs.ps1
+++ b/src/poshud/pages/inputs.ps1
@@ -29,7 +29,7 @@ $Select = {
 
 $DeclarativeInputs = {
     New-UDInput -Title "Try Me" -Endpoint {
-        param($Textbox, $Checkbox) 
+        param($Textbox, $Checkbox)
 
         New-UDInputAction -Toast "$Textbox : $Checkbox"
     } -Content {
@@ -50,7 +50,7 @@ $ReplacingContent = {
 
 
 New-UDPage -Name "Inputs" -Icon wpforms -Content {
-    New-UDPageHeader -Title "Inputs" -Icon "wpforms" -Description "Take input and perform actions." -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/inputs.html"
+    New-UDPageHeader -Title "Inputs" -Icon "wpforms" -Description "Take input and perform actions." -DocLink "https://docs.universaldashboard.io/components/inputs"
     New-UDExample -Title "Textboxes" -Description "Accept data from a textbox." -Script $Textboxes
     New-UDExample -Title "Checkboxes" -Description "Accept data from a checkbox." -Script $Checkboxes
     New-UDExample -Title "Select" -Description "Accept data from a select." -Script $Select

--- a/src/poshud/pages/monitors.ps1
+++ b/src/poshud/pages/monitors.ps1
@@ -1,7 +1,7 @@
 $Basic = {
     New-UDMonitor -Title "Downloads per second" -Type Line  -Endpoint {
         Get-Random -Minimum 0 -Maximum 10 | Out-UDMonitorData
-    } 
+    }
 }
 
 $RefreshIntervalDataRetention = {
@@ -17,7 +17,7 @@ $CustomColors = {
 }
 
 New-UDPage -Name "Monitors" -Icon chart_line -Content {
-    New-UDPageHeader -Title "Monitors" -Icon "line-chart" -Description "Visual data using dynamic charts that trace information over time" -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/monitors.html"
+    New-UDPageHeader -Title "Monitors" -Icon "line-chart" -Description "Visual data using dynamic charts that trace information over time" -DocLink "https://docs.universaldashboard.io/components/monitors"
     New-UDExample -Title "Basic Monitors" -Description "Create basic monitors from any type of data." -Script $Basic
     New-UDExample -Title "Customize refresh rate and data retention" -Description "Customize how often data is returned from the server and how much data to keep" -Script $RefreshIntervalDataRetention
     New-UDExample -Title "Custom colors" -Description "Adjust colors of different components within the monitor." -Script $CustomColors

--- a/src/poshud/pages/restapis.ps1
+++ b/src/poshud/pages/restapis.ps1
@@ -1,10 +1,10 @@
 $Users = @(
     [PSCustomObject]@{
-        id = 1
+        id   = 1
         name = "Adam"
     }
     [PSCustomObject]@{
-        id = 2
+        id   = 2
         name = "Frank"
     }
 )
@@ -22,9 +22,9 @@ $Parameters = {
         param($id)
 
         $Users | Where-Object Id -eq $id
-    }
+}
 
-    Invoke-RestMethod -Uri "https://poshud.com/api/user/1"
+Invoke-RestMethod -Uri "https://poshud.com/api/user/1"
 }
 
 $PostData = {
@@ -32,14 +32,14 @@ $PostData = {
         param($Body)
 
         $Body | ConvertTo-Json
-    }
+}
 
-    $Body = @{  value = "test" } 
-    Invoke-RestMethod -Uri "https://poshud.com/api/echo" -Method POST -Body  -ContentType "application/json"
+$Body = @{  value = "test" }
+Invoke-RestMethod -Uri "https://poshud.com/api/echo" -Method POST -Body  -ContentType "application/json"
 }
 
 New-UDPage -Name "REST APIs" -Icon code -Content {
-    New-UDPageHeader -Title "REST APIs" -Icon "code" -Description "Create REST APIs using PowerShell." -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/rest-apis.html"
+    New-UDPageHeader -Title "REST APIs" -Icon "code" -Description "Create REST APIs using PowerShell." -DocLink "https://docs.universaldashboard.io/rest-apis"
     New-UDExample -Title "Return data" -Description "Return data from REST APIs." -Script $CreateRestApis -NoRender
     New-UDExample -Title "Parameters" -Description "Accept parameters for your REST APIs." -Script $Parameters -NoRender
     New-UDExample -Title "POST Data" -Description "Post data to an endpoint." -Script $PostData -NoRender

--- a/src/poshud/pages/tables.ps1
+++ b/src/poshud/pages/tables.ps1
@@ -41,6 +41,6 @@ $Basic = {
 }
 
 New-UDPage -Name "Tables" -Icon table -Content {
-    New-UDPageHeader -Title "Tables" -Icon "table" -Description "Display data in a static table." -DocLink "https://adamdriscoll.gitbooks.io/powershell-universal-dashboard/content/tables.html"
+    New-UDPageHeader -Title "Tables" -Icon "table" -Description "Display data in a static table." -DocLink "https://docs.universaldashboard.io/components/tables"
     New-UDExample -Title "Basic Table" -Description "Display data in a table." -Script $Basic
 }


### PR DESCRIPTION
When I ran a new sample dashboard, I noticed that the documentation links still pointed to https://adamdriscoll.gitbooks.io.  I've updated them to the matching pages on https://docs.universaldashboard.io.  I also updated some links to point to the current repo for Universal Dashboard.  Hope this helps.
