### PR TITLE
Add type accelerator for DashboardColor

### DIFF
--- a/src/UniversalDashboard/UniversalDashboard.psm1
+++ b/src/UniversalDashboard/UniversalDashboard.psm1
@@ -14,3 +14,6 @@ Import-Module (Join-Path $PSScriptRoot "UniversalDashboardServer.psm1")
 Import-Module (Join-Path $PSScriptRoot "UniversalDashboard.Controls.psm1")
 Import-Module (Join-Path $PSScriptRoot "Modules\UniversalDashboard.Materialize\UniversalDashboard.Materialize.psd1")
 Import-Module (Join-Path $PSScriptRoot "Modules\UniversalDashboard.MaterialUI\UniversalDashboard.MaterialUI.psd1")
+
+$TAType = [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")
+$TAtype::Add("DashboardColor", "UniversalDashboard.Models.DashboardColor")


### PR DESCRIPTION
So [DashboardColor] can be used directly instead of referencing [UniversalDashboard.Models.DashboardColor]