### PR TITLE
New-UDGrid process section performance increase.

### DIFF
--- a/examples/server-performance-dashboard.ps1
+++ b/examples/server-performance-dashboard.ps1
@@ -114,7 +114,7 @@ Start-UdDashboard -Content {
                 New-UdRow {
                     New-UdColumn -Size 12 {
                         New-UdGrid -Title "Processes" -Headers @("Name", "ID", "Working Set", "CPU") -Properties @("Name", "Id", "WorkingSet", "CPU") -AutoRefresh -RefreshInterval 60 -Endpoint {
-                            Get-Process | Out-UDGridData
+                            Get-Process | Select Name,ID,WorkingSet,CPU | Out-UDGridData
                         }
                     }
                 }


### PR DESCRIPTION
The original version Get-Process | Out-UDGridData is inefficient and take a long time to generate. By limiting the properties sent to Out-UDGridData, process list is loaded significantly faster.