### PR TITLE
Update to add which EventId was called

### DIFF
--- a/src/UniversalDashboard/Server/DashboardHub.cs
+++ b/src/UniversalDashboard/Server/DashboardHub.cs
@@ -215,7 +215,7 @@ namespace UniversalDashboard
             {
                 variables.Add("EventData", eventData);
             }
-            variables.Add("EventId", EventId);
+            variables.Add("EventId", eventId);
 		
             variables.Add("MemoryCache", _memoryCache);
 

--- a/src/UniversalDashboard/Server/DashboardHub.cs
+++ b/src/UniversalDashboard/Server/DashboardHub.cs
@@ -215,7 +215,8 @@ namespace UniversalDashboard
             {
                 variables.Add("EventData", eventData);
             }
-
+            variables.Add("EventId", EventId);
+		
             variables.Add("MemoryCache", _memoryCache);
 
             try


### PR DESCRIPTION
This is just a quick modification to add which EventId is being called for instance when running a -OnChange { script block }
However when running this you will get the EventId for the "endpoint" running it, so for instance.
New-UDCheckbox -Id 'Group1' -Label 'Group 1' -OnChange {
 Show-UDToast -Message "You clicked on $EventId and toggled it to $EventData" -duration 8000
}

This can be useful when you build up a lot of checkboxes on a page dynamically and don't want to iterate over all of them to find out which one was changed...