### PR TITLE
Adding Dockerfile for UD Community Demo

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/powershell:latest
+LABEL description="Based on the Microfot Ubuntu 18.04 for Linux PowerShell Dockerfile that will download and start Universal Dashboard Community on port 8080" 
+
+# FROM: https://hub.docker.com/_/microsoft-powershell
+# Build: docker build . --tag=universaldashboarddemo
+# Run: docker run -it -p 8080:8080 universaldashboarddemo:latest 
+
+EXPOSE 8080
+COPY [ "./startdashboard.ps1", "/home/startdashboard.ps1" ]
+ENTRYPOINT ["pwsh", "/home/startdashboard.ps1"]

--- a/docker/startdashboard.ps1
+++ b/docker/startdashboard.ps1
@@ -1,0 +1,14 @@
+Write-Host "Installing Universal Dashboard Community Edition..."
+Install-module  UniversalDashboard.Community -AllowPrerelease -AcceptLicense -Force 
+Import-module UniversalDashboard.Community -Force 
+
+Write-Host "Starting Demo Dashboard..."
+
+Try{
+    Get-UDDashboard | Stop-UDDashboard
+    Start-UDDashboard -Port 8080
+    Read-Host "Universal Dashboard Community Edition is now running!"
+}
+Catch{
+    Write-Host "UniversalDashboard failed to start!"
+}


### PR DESCRIPTION
#### Added Example Ubuntu Dockerfile that will start Universal Dashboard Community on container startup
Added a Simple dockerfile directory. This dockerfile is based on Microsofts latest ubuntu PowerShell docker container.

DockerFile copies a simple script that upon execution of the container will download Universal Dashboard Community module and start the default dashboard on an exposed port 8080.

In the future, it would be nice to separate this from the Microsoft container AND install UD as a dockerfile run step and note require a separate .ps1 file - but this works for now! 

**How to Run**
Browse to the docker folder, we'll build with a . reference so the dockerfile and the startdashboard.ps1 will need to be in the current directory.
```cmd
docker build . --tag=universaldashboarddemo
docker run -it -p 8080:8080 universaldashboarddemo:latest 
```