### PR TITLE
Remove icon margin right inside a button

### DIFF
--- a/src/UniversalDashboard.Materialize/Components/ud-button.jsx
+++ b/src/UniversalDashboard.Materialize/Components/ud-button.jsx
@@ -24,7 +24,7 @@ export default class UDButton extends React.Component {
 
         var icon = null; 
         if (this.props.icon) {
-            icon = <UdIcon icon={this.props.icon} style={{marginRight: '5px'}}/>
+            icon = <UdIcon icon={this.props.icon} style={{marginRight: this.props.floating || !this.props.text ? 'unset' : '5px'}}/>
         }
 
         return <Button 


### PR DESCRIPTION
If the Text property is empty or the button type is floating the marginRight will be removed

Fix #1027 