### PR TITLE
Fix for #694

### DIFF
--- a/src/UniversalDashboard/Cmdlets/Inputs/NewInputFieldCommand.cs
+++ b/src/UniversalDashboard/Cmdlets/Inputs/NewInputFieldCommand.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace UniversalDashboard.Cmdlets.Inputs
 {
-	[Cmdlet(VerbsCommon.New, "UDInputField")]
+    [Cmdlet(VerbsCommon.New, "UDInputField")]
     public class NewInputFieldCommand : PSCmdlet
     {
         [Parameter(Mandatory = true)]
@@ -44,6 +44,10 @@ namespace UniversalDashboard.Cmdlets.Inputs
         private readonly Logger Log = LogManager.GetLogger(nameof(NewInputFieldCommand));
 		protected override void EndProcessing()
 		{
+            if (Type == "select" && (null == DefaultValue || DefaultValue.ToString() == "") && Values.Count() >= 0)
+            {
+                DefaultValue = Values[0];
+            }
 			var field = new Field
 			{
 				Name = Name,


### PR DESCRIPTION
This will make sure that new-udinputfield -type select always gets a defaultvalue if it contains more than 0 values so it will not be null anymore.