### PR TITLE
Default theme update - Padding, Background Color, MaterialUI Color Spec

### DIFF
--- a/src/UniversalDashboard/Themes/Default.psd1
+++ b/src/UniversalDashboard/Themes/Default.psd1
@@ -21,7 +21,7 @@
         }
 
         '.btn:hover' = @{
-            'background-color' = "#002984"
+            'background-color' = "#2c387e"
         }
 
         '.btn-floating' = @{

--- a/src/UniversalDashboard/Themes/Default.psd1
+++ b/src/UniversalDashboard/Themes/Default.psd1
@@ -1,17 +1,57 @@
 @{
     Name = "Default"
     Definition = @{
+        
         UDDashboard = @{
-            BackgroundColor = "rgb(255,255,255)"
-            FontColor = "rgb(0, 0, 0)"
+            BackgroundColor = "#EEEEEE"
+            FontColor = "#111111"
+            
         }
         UDNavBar = @{
-            BackgroundColor = "rgb(36, 81, 131)"
-            FontColor = "rgb(255, 255, 255)"
+            BackgroundColor = "#3f51b5"
+            FontColor = "#ffffff"
         }
         UDFooter = @{
-            BackgroundColor = "rgb(36, 81, 131)"
-            FontColor = "rgb(255, 255, 255)"
+            BackgroundColor = "#3f51b5"
+            FontColor = "#ffffff"
         }
+
+        '.btn' = @{
+            'background-color' = "#3f51b5"
+        }
+
+        '.btn:hover' = @{
+            'background-color' = "#002984"
+        }
+
+        '.btn-floating' = @{
+            'background-color' = "#3f51b5"
+        }
+
+        'main' = @{
+            'padding-left' = "50px"
+            'padding-right' = "50px"
+            'padding-top' = "50px"
+            'padding-bottom' = "50px"
+        }
+
+        '[type="radio"]:checked + span::after' = @{
+            'background-color' = "#3f51b5"
+        }
+
+        '[type="checkbox"]:checked + span:not(.lever)::before' = @{
+            "border-right" = "2px solid #3f51b5"
+            "border-bottom" = "2px solid #3f51b5"
+        }
+
+        '.pagination li a'= @{
+            'color' = "#3f51b5"
+        }
+
+        '.pagination li.active' = @{
+            'color' = "#111111 !important"
+            'background-color' = "#3f51b5"
+        }
+
     }
 }


### PR DESCRIPTION
PR for: https://github.com/ironmansoftware/universal-dashboard/issues/1031 - Changed the default blue to match the spec on Material UI since we weren't REALLY married to the existing blue: https://material-ui.com/customization/color/#color-tool

* Specifically utilizing these shades of blue:
  * Primary:  ``#3f51b5``
  * Secondary ``#2c387e``

* Main Font Color is new ``#111111`` instead of ``#000000`` for eye strain ease reading black text on white background.

* Adding 50px padding to main - this prevents elements to going from screen ends and makes it look much nicer. This does reduce usable screen space - but in this case it makes default dashboards look much sexier.

* ``#EEEEEE`` light gray background color seperates dashboard elements from background and gives a nice "3d" look.

With no customization new dashboards will look like this out of the box - it's a step in the right direction:
![image](https://user-images.githubusercontent.com/274883/63653861-271fc400-c738-11e9-8be3-3aca9deba4e1.png)

https://github.com/ironmansoftware/universal-dashboard/issues/1031