### PR TITLE
New and Improved Indigo Themed Sidenav

### DIFF
--- a/src/UniversalDashboard/Themes/Default.psd1
+++ b/src/UniversalDashboard/Themes/Default.psd1
@@ -98,11 +98,38 @@
         }
     
         '.sidenav li>a' = @{
-            'color' = "#111111"
+            'color' = "#FFFFFF"
+            'background-color' = "#3f51b5"
         }
        
         '.sidenav li>a:hover' = @{
+            'background-color' = "#2c387e"
+        }
+    
+        '.sidenav.sidenav-fixed' = @{
             'background-color' = "#3f51b5"
+        }
+    
+        '.sidenav' = @{
+            'background-color' = "#3f51b5"
+        }
+    
+        '.sidenav .subheader' = @{
+            'color'= "#ffffff"
+            'font-size' = 'large'
+        }
+    
+        '.sidenav .divider' = @{
+            'background-color' = "#2c387e"
+        }
+    
+        '.sidenav .collapsible-header' = @{
+            'color'= "#ffffff"
+            'font-size' = 'large'
+        }
+    
+        '.sidenav .collapsible-header:hover' = @{
+            'color'= "#ffffff"
         }
     
 


### PR DESCRIPTION
Alright, hear me out... 

After submitting the recent PR for the default theme improvements - I was playing around with SideNav. Applying the Indigo [Material-UI Color](https://material-ui.com/customization/color/) as the background behind white text looks amazing. I propose making this the new default! It very much looks like a cool "hipster" web application.

![image](https://user-images.githubusercontent.com/274883/63909662-19dd3080-c9e9-11e9-8ee7-39707517856b.png)


**Note** - Besides color change: 


collapsible-header and subheader have been given 'font-size' = 'large' to help make them standout against the normal elements.

Works for FIXED and non fixed.

**ScreenShots**


![navb](https://user-images.githubusercontent.com/274883/63909719-6d4f7e80-c9e9-11e9-84ed-f8be01b361da.gif)


![image](https://user-images.githubusercontent.com/274883/63909603-e13d5700-c9e8-11e9-99c4-e48fce182c02.png)
