### PR TITLE
img with float parameter causing layout issues.

### DIFF
--- a/src/UniversalDashboard/Themes/Azure.psd1
+++ b/src/UniversalDashboard/Themes/Azure.psd1
@@ -160,9 +160,6 @@
       '.collection .collection-item'= @{
           'background-color' = "#252525"
       }
-      'img' = @{
-          'float'= "left"
-      }
       '.pagination li.active' = @{
           'background-color' = "#FFFFFF"
       }


### PR DESCRIPTION
img appear in-between ud-cards because of it. 
Other themes do not have their img tag set to float.