### PR TITLE
ProgressBar Color Fix

### DIFF
--- a/src/UniversalDashboard/Themes/Default.psd1
+++ b/src/UniversalDashboard/Themes/Default.psd1
@@ -131,7 +131,14 @@
         '.sidenav .collapsible-header:hover' = @{
             'color'= "#ffffff"
         }
+
+        '.progress' = @{
+            'background-color' = '#8c9eff'
+        }
     
+        '.progress .determinate, .progress .indeterminate' = @{
+            'background-color' = '#3f51b5'
+        }  
 
     }
 }


### PR DESCRIPTION
Addressing: https://github.com/ironmansoftware/universal-dashboard/issues/1071

Used Material-UI Color:
Background Color: `#8c9eff`
ForeGround Progress Color: `#3f51b5` - this is the default primary "Indigo"

Still utilizing that: https://material-ui.com/customization/color/

![progressfix](https://user-images.githubusercontent.com/274883/64058058-0063f200-cb6b-11e9-9013-82a69081002d.gif)