### PR TITLE
Collapsible Fixes for issue 1149

### DIFF
--- a/src/UniversalDashboard.Materialize/Scripts/collapsible.ps1
+++ b/src/UniversalDashboard.Materialize/Scripts/collapsible.ps1
@@ -5,7 +5,7 @@ function New-UDCollapsible {
         [Parameter(Mandatory = $true, Position = 0)]
         [ScriptBlock]$Items,
         [Parameter()]
-        [UniversalDashboard.Models.DashboardColor]$BackgroundColor = 'White',
+        [UniversalDashboard.Models.DashboardColor]$BackgroundColor = 'Transparent',
         [Parameter()]
         [UniversalDashboard.Models.DashboardColor]$FontColor = 'Black',
         [Parameter()]

--- a/src/UniversalDashboard/Models/DashboardColor.cs
+++ b/src/UniversalDashboard/Models/DashboardColor.cs
@@ -58,7 +58,7 @@ namespace UniversalDashboard.Models
 
 				return new DashboardColor(iColorInt);
 			}
-			else if (hexOrName.Equals("Transparent"))
+			else if ((hexOrName.ToLower()).Equals("transparent"))
 			{
 				var color = Color.FromArgb(0, 0, 0, 0);
 

--- a/src/UniversalDashboard/Models/DashboardColor.cs
+++ b/src/UniversalDashboard/Models/DashboardColor.cs
@@ -58,6 +58,14 @@ namespace UniversalDashboard.Models
 
 				return new DashboardColor(iColorInt);
 			}
+			else if (hexOrName.Equals("Transparent"))
+			{
+				var color = Color.FromArgb(0, 0, 0, 0);
+
+				log.Debug($"Parse - color = {color}");
+
+				return new DashboardColor(color);
+			}
 			else
 			{
 				var color = Color.FromName(hexOrName);

--- a/src/UniversalDashboard/Themes/Default.psd1
+++ b/src/UniversalDashboard/Themes/Default.psd1
@@ -310,8 +310,8 @@ $AlternativeBackgroundColor3 = $BackgroundColorBright
         }
 
         '.page-footer .footer-copyright' = @{
-            'background-color' = $PrimaryBackgroundColor
+            'background-color' = $PrimaryColor
         }
-        
+
     }
 }


### PR DESCRIPTION
#### Changes
* Adding "Transparent" String handling to Dashboard Color Class
* Set Default $BackgroundColor  of UDcollapsible to 'Transparent'

Addresses: https://github.com/ironmansoftware/universal-dashboard/issues/1149

#### Testing

**Testing - Note you can still of course specify a background, but it looks good without specfiying a background since the default is now transparent.
```powershell
    New-UDCollapsible -Popout -Items {
        # Get value (show websocket)

        New-UDCollapsibleItem -Title "Get-UDfsfaElement" -Content {
            New-UDTextbox -Label "Enter srome text" -Id 'MyTextbox'
            New-UDButton -Text 'Get the text' -OnClick {
                Show-UDToast -Message (Get-UDElement -Id 'MyTextbox').Attributes['value']
            }
        }

  
        New-UDCollapsibleItem -Title "THE BLUE BOY" -Content {
            New-UDTextbox -Label "Enter some text" -Id 'MyTextbox'
            New-UDButton -Text 'Get the text' -OnClick {
                Show-UDToast -Message (Get-UDElement -Id 'MyTextbox').Attributes['value']
            }
        } -BackgroundColor "Blue"


        New-UDCollapsibleItem -Title "Get-MyTest" -Content {
            New-UDTextbox -Label "Enter some text" -Id 'MyTextbox'
            New-UDButton -Text 'Get the text' -OnClick {
                Show-UDToast -Message (Get-UDElement -Id 'MyTextbox').Attributes['value']
            }
        }
    }
```
![image](https://user-images.githubusercontent.com/274883/65650741-b0454780-dfd1-11e9-956b-c480b4f397eb.png)


```powershell
New-UDCard -Title "Your Employees" -Content {
            "Welcome to Card Town"
        } -BackgroundColor "transparent"
```

![image](https://user-images.githubusercontent.com/274883/65650676-7d02b880-dfd1-11e9-9228-d463ab6b4c64.png)
