### PR TITLE
Copyright color fixes

### DIFF
--- a/src/UniversalDashboard.Materialize/Components/ud-footer.jsx
+++ b/src/UniversalDashboard.Materialize/Components/ud-footer.jsx
@@ -23,7 +23,7 @@ export default class UdFooter extends React.Component {
             var fontColor = this.props.footer.fontColor ? this.props.footer.fontColor : this.props.fontColor;
 
             return <footer className="page-footer ud-footer" style={{backgroundColor: backgroundColor, color: fontColor}}>
-                <div className="footer-copyright">
+                <div className="footer-copyright" style={{backgroundColor: backgroundColor, color: fontColor}}>>
                     <div className="container">
                         {this.props.footer.copyright}
                         <div className="right">

--- a/src/UniversalDashboard/Cmdlets/NewFooterCommand.cs
+++ b/src/UniversalDashboard/Cmdlets/NewFooterCommand.cs
@@ -27,7 +27,7 @@ namespace UniversalDashboard.Cmdlets.Formatting
 			var footer = new Footer();
 
 			footer.BackgroundColor = BackgroundColor?.HtmlColor;
-			footer.FontColor = BackgroundColor?.HtmlColor;
+			footer.FontColor = FontColor?.HtmlColor;
 			footer.Links = Links;
 			footer.Copyright = Copyright;
 

--- a/src/UniversalDashboard/Models/Footer.cs
+++ b/src/UniversalDashboard/Models/Footer.cs
@@ -7,10 +7,13 @@ namespace UniversalDashboard.Models
     {
 		[JsonProperty("links")]
 		public Hashtable[] Links { get; set; }
+        
         [JsonProperty("copyright")]
         public string Copyright {get;set;}
-        [JsonProperty("title")]
+        
+        [JsonProperty("backgroundColor")]
         public string BackgroundColor {get;set;}
+        
         [JsonProperty("fontColor")]
         public string FontColor {get;set;}
 

--- a/src/UniversalDashboard/Themes/Default.psd1
+++ b/src/UniversalDashboard/Themes/Default.psd1
@@ -310,8 +310,8 @@ $AlternativeBackgroundColor3 = $BackgroundColorBright
         }
 
         '.page-footer .footer-copyright' = @{
-            'background-color' = $PrimaryBackgroundColor
+            'background-color' = $PrimaryColor
         }
-        
+
     }
 }


### PR DESCRIPTION
#### Fixes
* Some bugs on footer color assignment since the first commit :)
* Applied Footer Styling to Footer and Copyright DIV

#### Testing / Examples
```powershell
$Footer = New-UDFooter -Copyright 'Copyright - "The Internet"' -BackgroundColor "Red" -FontColor "Purple"
```

![image](https://user-images.githubusercontent.com/274883/65652872-df12ec00-dfd8-11e9-92a2-415c658e5298.png)



```powershell
$Footer = New-UDFooter -Copyright 'Copyright - "The Internet"' -BackgroundColor "Transparent" -FontColor "#e91e63"
```
![image](https://user-images.githubusercontent.com/274883/65652936-14b7d500-dfd9-11e9-8230-151456da05f8.png)
