### PR TITLE
New-UDTable creates unnamed endpoint

### DIFF
--- a/src/UniversalDashboard.Materialize/Scripts/table.ps1
+++ b/src/UniversalDashboard.Materialize/Scripts/table.ps1
@@ -60,7 +60,7 @@ function New-UDTable {
 					New-UDElement -Tag 'tbody' -Content $Content
 				}
 				else {
-					New-UDElement -Tag 'tbody' -Endpoint $Endpoint -AutoRefresh:$AutoRefresh -RefreshInterval $RefreshInterval -ArgumentList $ArgumentList
+					New-UDElement -Tag 'tbody' -Endpoint $Endpoint -AutoRefresh:$AutoRefresh -RefreshInterval $RefreshInterval -ArgumentList $ArgumentList -Id "$Id-tbody'
 				}
 
 				


### PR DESCRIPTION
Add a deterministic ID to the UDElement created by New-UDTable.  Without this any UDTable will create an endpoint with a new random GUID every time the dashboard is restarted.  That causes clients with their browser open during a dashboard restart to suddenly get 404 errors.

I used "$Id-tbody" as the ID of the endpoint but any value based on $Id should work. 