### PR TITLE
Fixes #748

### DIFF
--- a/src/UniversalDashboard/Controllers/ComponentController.cs
+++ b/src/UniversalDashboard/Controllers/ComponentController.cs
@@ -383,7 +383,7 @@ namespace UniversalDashboard.Controllers
 
             SetQueryStringValues(variables);
 
-            if (!await TryProcessBodyAsFormOrMultipart(Request, variables))
+            if (!await TryProcessBodyAsFormOrFile(Request, variables))
             { 
                 //If we made it here we either have a non-form content type
                 //or the request was made with the default content type of form
@@ -402,25 +402,10 @@ namespace UniversalDashboard.Controllers
 			return StatusCode(404);
 		}
 
-        private async Task<bool> TryProcessBodyAsFormOrMultipart(HttpRequest request, Dictionary<string,object> variables)
+        private async Task<bool> TryProcessBodyAsFormOrFile(HttpRequest request, Dictionary<string,object> variables)
         {
             if (HttpContext.Request.HasFormContentType)
-            {
-                if (HttpContext.Request.ContentType == "multipart/form-data") {
-                    Log.Debug("HasMultipartcontenttype");
-
-                    var filePath = Path.GetTempFileName();
-                    Log.Debug($"Got path {filePath}");
-
-                    using (var stream = System.IO.File.Create(filePath))
-                    {
-                        await HttpContext.Request.Body.CopyToAsync(stream);
-                    }
-                    return true;
-                }
-                else {
-                    Log.Debug(HttpContext.Request.ContentType);
-                }
+            {     
                 Log.Debug("HasFormContentType");
 
                 var form = await Request.ReadFormAsync(new FormOptions() { BufferBody = true });
@@ -436,6 +421,29 @@ namespace UniversalDashboard.Controllers
                         }
                     }
                     return true;
+                }
+            }
+            if (HttpContext.Request.ContentType.Contains("image/") || HttpContext.Request.ContentType.Contains("file/")) 
+            {
+                Log.Debug("HasFileOrImageContenttype");
+                using (MemoryStream stream = new MemoryStream())
+                {
+                    await HttpContext.Request.Body.CopyToAsync(stream);
+                    foreach (var header in HttpContext.Request.Headers) {
+                        Log.Debug(header);
+
+                    } 
+                    if (stream != null) {
+                        variables.Add("File", stream.ToArray());
+                        Log.Debug("File from RESTAPI found.");
+                        return true;
+                    }
+                    else 
+                    {
+                        Log.Debug("Filestream is empty.");
+                        //return it true, to prevent it from processing it as RAW
+                        return true;
+                    }
                 }
             }
             return false;
@@ -463,11 +471,12 @@ namespace UniversalDashboard.Controllers
 			var variables = new Dictionary<string, object>();
             SetQueryStringValues(variables);
 
-            if (!await TryProcessBodyAsFormOrMultipart(Request, variables))
+            if (!await TryProcessBodyAsFormOrFile(Request, variables))
             { 
                 //If we made it here we either have a non-form content type
                 //or the request was made with the default content type of form
                 //when it is really something else (probably application/json)
+                Log.Debug("Processing as RAW");
                 ProcessBodyAsRaw(Request, variables);                              
             }
 
@@ -494,7 +503,7 @@ namespace UniversalDashboard.Controllers
 			var variables = new Dictionary<string, object>();
             SetQueryStringValues(variables);
 
-            if (!await TryProcessBodyAsFormOrMultipart(Request, variables))
+            if (!await TryProcessBodyAsFormOrFile(Request, variables))
             {
                 //If we made it here we either have a non-form content type
                 //or the request was made with the default content type of form

--- a/src/UniversalDashboard/Controllers/ComponentController.cs
+++ b/src/UniversalDashboard/Controllers/ComponentController.cs
@@ -429,10 +429,7 @@ namespace UniversalDashboard.Controllers
                 using (MemoryStream stream = new MemoryStream())
                 {
                     await HttpContext.Request.Body.CopyToAsync(stream);
-                    foreach (var header in HttpContext.Request.Headers) {
-                        Log.Debug(header);
-
-                    } 
+                    
                     if (stream != null) {
                         variables.Add("File", stream.ToArray());
                         Log.Debug("File from RESTAPI found.");

--- a/src/UniversalDashboard/Controllers/ComponentController.cs
+++ b/src/UniversalDashboard/Controllers/ComponentController.cs
@@ -422,24 +422,27 @@ namespace UniversalDashboard.Controllers
                     }
                     return true;
                 }
+		return false;
             }
-            if (HttpContext.Request.ContentType.Contains("image/") || HttpContext.Request.ContentType.Contains("file/")) 
-            {
-                Log.Debug("HasFileOrImageContenttype");
-                using (MemoryStream stream = new MemoryStream())
+	    if (HttpContext.Request.Method == "POST") {
+                //file upload only avaliable in POST method.
+                if (HttpContext.Request.ContentType.Contains("image/") || HttpContext.Request.ContentType.Contains("file/")) 
                 {
-                    await HttpContext.Request.Body.CopyToAsync(stream);
-                    
-                    if (stream != null) {
-                        variables.Add("File", stream.ToArray());
-                        Log.Debug("File from RESTAPI found.");
-                        return true;
-                    }
-                    else 
+                    Log.Debug("HasFileOrImageContenttype");
+                    using (MemoryStream stream = new MemoryStream())
                     {
-                        Log.Debug("Filestream is empty.");
-                        //return it true, to prevent it from processing it as RAW
-                        return true;
+                        await HttpContext.Request.Body.CopyToAsync(stream);
+                        if (stream != null) {
+                            variables.Add("File", stream.ToArray());
+                            Log.Debug("File from RESTAPI found.");
+                            return true;
+                        }
+                        else 
+                        {
+                            Log.Debug("Filestream is empty.");
+                            //return it true, to prevent it from processing it as RAW
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Allows for file upload via REST -api.
Note: the original file name is not included in the request. 
However, added support for "wildcard" contenttype: ie: file/* and image/* in order to reconstruct. 
Readable from the HTTP Request in Endpoint. 

See 
https://hastebin.com/tediyiqahi.bash 
for Powershell Example.

For uploading files -contenttype must be specified according to pattern. 