### PR TITLE
Added security for REST Fixes #1262

### DIFF
--- a/src/UniversalDashboard/Cmdlets/NewEndpointCommand.cs
+++ b/src/UniversalDashboard/Cmdlets/NewEndpointCommand.cs
@@ -31,6 +31,9 @@ namespace UniversalDashboard.Cmdlets
 		[ValidateSet("GET", "POST", "DELETE", "PUT")]
 		public string Method { get; set; } = "GET";
 
+        [Parameter(ParameterSetName = "Rest")]
+        public SwitchParameter AcceptFileUpload {get; set;}
+
         [Parameter(Mandatory = true, ParameterSetName = "Scheduled")]
         public EndpointSchedule Schedule { get; set; }
 
@@ -66,7 +69,9 @@ namespace UniversalDashboard.Cmdlets
             {
                 WriteWarning(ex.Message);
             }
-
+            if (AcceptFileUpload) {
+                callback.AcceptFileUpload = true;
+            }
 
             if (EvaluateUrlAsRegex) {
                 callback.UrlRegEx = new Regex(Url);

--- a/src/UniversalDashboard/Controllers/ComponentController.cs
+++ b/src/UniversalDashboard/Controllers/ComponentController.cs
@@ -430,25 +430,21 @@ namespace UniversalDashboard.Controllers
 
         private async Task<bool> TryProcessFile (HttpRequest request, Dictionary<string,object> variables)
         {
-            if (HttpContext.Request.Method == "POST") {
-                //file upload only avaliable in POST method.
-                if (HttpContext.Request.ContentType.Contains("image/") || HttpContext.Request.ContentType.Contains("file/")) 
+            if (HttpContext.Request.ContentType.Contains("image/") || HttpContext.Request.ContentType.Contains("file/")) 
+            {
+                Log.Debug("HasFileOrImageContenttype");
+                using (MemoryStream stream = new MemoryStream())
                 {
-                    Log.Debug("HasFileOrImageContenttype");
-                    using (MemoryStream stream = new MemoryStream())
+                    await HttpContext.Request.Body.CopyToAsync(stream);
+                    if (stream != null) {
+                        variables.Add("File", stream.ToArray());
+                        Log.Debug("File from RESTAPI found.");
+                        return true;
+                    }
+                    else 
                     {
-                        await HttpContext.Request.Body.CopyToAsync(stream);
-                        if (stream != null) {
-                            variables.Add("File", stream.ToArray());
-                            Log.Debug("File from RESTAPI found.");
-                            return true;
-                        }
-                        else 
-                        {
-                            Log.Debug("Filestream is empty.");
-                            //return it true, to prevent it from processing it as RAW
-                            return true;
-                        }
+                        Log.Debug("Filestream is empty.");
+                        return false;
                     }
                 }
             }
@@ -476,20 +472,29 @@ namespace UniversalDashboard.Controllers
 
 			var variables = new Dictionary<string, object>();
             SetQueryStringValues(variables);
-            if (!await TryProcessBodyAsForm(Request, variables))
-            { 
-                //If we made it here we either have a non-form content type
-                //or the request was made with the default content type of form
-                //when it is really something else (probably application/json)
-                Log.Debug("Processing as RAW");
-                ProcessBodyAsRaw(Request, variables);                              
+            
+            if (!HttpContext.Request.ContentType.Contains("image/") && !HttpContext.Request.ContentType.Contains("file/")) 
+            {
+                if (!await TryProcessBodyAsForm(Request, variables))
+                { 
+                    //If we made it here we either have a non-form content type
+                    //or the request was made with the default content type of form
+                    //when it is really something else (probably application/json)
+                    Log.Debug("Processing as RAW");
+                    ProcessBodyAsRaw(Request, variables);                              
+                }
             }
 
-            var endpoint = _dashboardService.EndpointService.GetByUrl(parts, "POST", variables);
             
+            var endpoint = _dashboardService.EndpointService.GetByUrl(parts, "POST", variables);
+ 
             if (endpoint.AcceptFileUpload) {
-                if (!await TryProcessBodyAsForm(Request, variables)) {
+                if (await TryProcessFile(Request, variables)) {
                     Log.Debug("Reccieved a file!");
+                    
+                }
+                else {
+                    Log.Debug("Endpoint supported file content, but no files present.");
                 }
             }
             if (endpoint != null)

--- a/src/UniversalDashboard/Controllers/ComponentController.cs
+++ b/src/UniversalDashboard/Controllers/ComponentController.cs
@@ -383,7 +383,7 @@ namespace UniversalDashboard.Controllers
 
             SetQueryStringValues(variables);
 
-            if (!await TryProcessBodyAsFormOrFile(Request, variables))
+            if (!await TryProcessBodyAsForm(Request, variables))
             { 
                 //If we made it here we either have a non-form content type
                 //or the request was made with the default content type of form
@@ -402,7 +402,7 @@ namespace UniversalDashboard.Controllers
 			return StatusCode(404);
 		}
 
-        private async Task<bool> TryProcessBodyAsFormOrFile(HttpRequest request, Dictionary<string,object> variables)
+        private async Task<bool> TryProcessBodyAsForm (HttpRequest request, Dictionary<string,object> variables)
         {
             if (HttpContext.Request.HasFormContentType)
             {     
@@ -422,9 +422,15 @@ namespace UniversalDashboard.Controllers
                     }
                     return true;
                 }
-		return false;
+		        return false;
             }
-	    if (HttpContext.Request.Method == "POST") {
+            return false;
+	        
+        }
+
+        private async Task<bool> TryProcessFile (HttpRequest request, Dictionary<string,object> variables)
+        {
+            if (HttpContext.Request.Method == "POST") {
                 //file upload only avaliable in POST method.
                 if (HttpContext.Request.ContentType.Contains("image/") || HttpContext.Request.ContentType.Contains("file/")) 
                 {
@@ -470,8 +476,7 @@ namespace UniversalDashboard.Controllers
 
 			var variables = new Dictionary<string, object>();
             SetQueryStringValues(variables);
-
-            if (!await TryProcessBodyAsFormOrFile(Request, variables))
+            if (!await TryProcessBodyAsForm(Request, variables))
             { 
                 //If we made it here we either have a non-form content type
                 //or the request was made with the default content type of form
@@ -481,6 +486,12 @@ namespace UniversalDashboard.Controllers
             }
 
             var endpoint = _dashboardService.EndpointService.GetByUrl(parts, "POST", variables);
+            
+            if (endpoint.AcceptFileUpload) {
+                if (!await TryProcessBodyAsForm(Request, variables)) {
+                    Log.Debug("Reccieved a file!");
+                }
+            }
             if (endpoint != null)
             {
                 return await RunScript(endpoint, variables);
@@ -503,7 +514,7 @@ namespace UniversalDashboard.Controllers
 			var variables = new Dictionary<string, object>();
             SetQueryStringValues(variables);
 
-            if (!await TryProcessBodyAsFormOrFile(Request, variables))
+            if (!await TryProcessBodyAsForm(Request, variables))
             {
                 //If we made it here we either have a non-form content type
                 //or the request was made with the default content type of form

--- a/src/UniversalDashboard/Models/Endpoint.cs
+++ b/src/UniversalDashboard/Models/Endpoint.cs
@@ -27,6 +27,7 @@ namespace UniversalDashboard.Models
         public string SessionId { get; set; }
         internal Page Page { get; set; }
         public Regex UrlRegEx { get; set; }
+        public bool AcceptFileUpload {get; set;}
     }
 
     public class Part


### PR DESCRIPTION
By allowing you to specify a switch on POST endpoints if fileupload should be allowed. Default disabled.
If you upload a file on a non-fileuploadaccepting endpoint, no errors will be presented, but no data is processed from the body or passed to the scriptblock.

And yes... i did test the api integration tests this time O:-) 
