### PR TITLE
Added invoke-udjavascript command

### DIFF
--- a/src/UniversalDashboard/Cmdlets/Invoke-UDJavaScript.cs
+++ b/src/UniversalDashboard/Cmdlets/Invoke-UDJavaScript.cs
@@ -10,13 +10,13 @@ namespace UniversalDashboard.Cmdlets
 		//private readonly Logger Log = LogManager.GetLogger(nameof(SelectUDElementCommand));
 
         [Parameter(Mandatory = true)]
-		public string jsscript { get; set; }
+		public string JavaScript { get; set; }
 
         protected override void EndProcessing()
         {
             var hub = this.GetVariableValue("DashboardHub") as IHubContext<DashboardHub>;
             var connectionId = this.GetVariableValue("ConnectionId") as string;   
-            hub.InvokeJavaScript(connectionId, jsscript).Wait();
+            hub.InvokeJavaScript(connectionId, JavaScript).Wait();
 		}
 	}
 }

--- a/src/UniversalDashboard/Cmdlets/Invoke-UDJavaScript.cs
+++ b/src/UniversalDashboard/Cmdlets/Invoke-UDJavaScript.cs
@@ -1,0 +1,22 @@
+using NLog;
+using System.Management.Automation;
+using Microsoft.AspNetCore.SignalR;
+
+namespace UniversalDashboard.Cmdlets
+{
+    [Cmdlet(VerbsLifecycle.Invoke, "UDJavaScript")]
+    public class InvokeUDJavaScriptCommand : PSCmdlet
+    {
+		//private readonly Logger Log = LogManager.GetLogger(nameof(SelectUDElementCommand));
+
+        [Parameter(Mandatory = true)]
+		public string jsscript { get; set; }
+
+        protected override void EndProcessing()
+        {
+            var hub = this.GetVariableValue("DashboardHub") as IHubContext<DashboardHub>;
+            var connectionId = this.GetVariableValue("ConnectionId") as string;   
+            hub.InvokeJavaScript(connectionId, jsscript).Wait();
+		}
+	}
+}

--- a/src/UniversalDashboard/New-UDModuleManifest.ps1
+++ b/src/UniversalDashboard/New-UDModuleManifest.ps1
@@ -154,7 +154,8 @@ $manifestParameters = @{
 						"Show-UDModal",
 						"Hide-UDModal",
 						"Select-UDElement",
-						"Set-UDClipboard",
+                        "Set-UDClipboard",
+                        "Invoke-UDJavaScript",
 						"Hide-UDToast"
 						"Publish-UDFolder"
 						"New-UDEndpointInitialization"

--- a/src/UniversalDashboard/Server/DashboardHub.cs
+++ b/src/UniversalDashboard/Server/DashboardHub.cs
@@ -54,9 +54,9 @@ namespace UniversalDashboard
             await hub.Clients.Client(clientId).SendAsync("select", ID, scrollToElement);
         }
 
-        public static async Task InvokeJavaScript(this IHubContext<DashboardHub> hub, string clientId, string jsscript)
+        public static async Task InvokeJavaScript(this IHubContext<DashboardHub> hub, string clientId, string JavaScript)
         {
-            await hub.Clients.Client(clientId).SendAsync("invokejavascript", jsscript);
+            await hub.Clients.Client(clientId).SendAsync("invokejavascript", JavaScript);
         }
 
         public static async Task Clipboard(this IHubContext<DashboardHub> hub, string clientId, string Data, bool toastOnSuccess, bool toastOnError)

--- a/src/UniversalDashboard/Server/DashboardHub.cs
+++ b/src/UniversalDashboard/Server/DashboardHub.cs
@@ -54,6 +54,11 @@ namespace UniversalDashboard
             await hub.Clients.Client(clientId).SendAsync("select", ID, scrollToElement);
         }
 
+        public static async Task InvokeJavaScript(this IHubContext<DashboardHub> hub, string clientId, string jsscript)
+        {
+            await hub.Clients.Client(clientId).SendAsync("invokejavascript", jsscript);
+        }
+
         public static async Task Clipboard(this IHubContext<DashboardHub> hub, string clientId, string Data, bool toastOnSuccess, bool toastOnError)
         {
             await hub.Clients.Client(clientId).SendAsync("clipboard", Data, toastOnSuccess ,toastOnError);

--- a/src/client/src/app/ud-dashboard.jsx
+++ b/src/client/src/app/ud-dashboard.jsx
@@ -133,6 +133,10 @@ export default class UdDashboard extends React.Component {
             }
         });
 
+        connection.on('invokejavascript', (jsscript) => {
+            eval(jsscript);
+        });
+
         connection.on('clipboard', (Data, toastOnSuccess, toastOnError) => {
             var textArea = document.createElement("textarea");
             textArea.style.position = 'fixed';


### PR DESCRIPTION
Allows for custom javascript executed clientside on demand. 
See https://github.com/BoSen29/Discussion/blob/master/invoke-udjavascript.ps1 for example usage.

The javascript "codeblock" is passed as string, and then ran clientside.

Should be able to fixe https://forums.universaldashboard.io/t/image-to-fill-screen-no-edge-borders/1593/3 using this.